### PR TITLE
fix: improve aeochecker score alignment, security fixes, and schema generation

### DIFF
--- a/src/core/ai-index.test.ts
+++ b/src/core/ai-index.test.ts
@@ -28,6 +28,7 @@ const baseConfig: ResolvedAeoConfig = {
     manifest: true,
     sitemap: true,
     aiIndex: true,
+    schema: true,
   },
   robots: { allow: ['/'], disallow: [], crawlDelay: 0, sitemap: '' },
   widget: {
@@ -37,6 +38,17 @@ const baseConfig: ResolvedAeoConfig = {
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+  },
+  schema: {
+    enabled: true,
+    organization: { name: 'Test', url: 'https://example.com', logo: '', sameAs: [] },
+    defaultType: 'WebPage',
+  },
+  og: {
+    enabled: false,
+    image: '',
+    twitterHandle: '',
+    type: 'website',
   },
 };
 

--- a/src/core/audit.ts
+++ b/src/core/audit.ts
@@ -156,7 +156,7 @@ function auditContentStructure(config: ResolvedAeoConfig, issues: AuditIssue[], 
 
 /**
  * Category 3: Schema Presence (0-20)
- * Checks: schema enabled, organization info, sameAs, defaultType, schema.json generated
+ * Checks: schema enabled, organization info, FAQ/HowTo patterns, Article/WebPage type
  */
 function auditSchemaPresence(config: ResolvedAeoConfig, issues: AuditIssue[], suggestions: string[]): AuditCategory {
   const checks: AuditCategory['checks'] = [];
@@ -182,18 +182,21 @@ function auditSchemaPresence(config: ResolvedAeoConfig, issues: AuditIssue[], su
     suggestions.push('Add schema.organization.logo for richer search results and AI knowledge');
   }
 
-  // sameAs social profiles (4 pts)
-  const hasSameAs = config.schema.organization.sameAs.length > 0;
-  checks.push({ label: 'Social profiles linked (sameAs)', passed: hasSameAs, points: hasSameAs ? 4 : 0 });
-  if (!hasSameAs) {
-    issues.push({ category: 'Schema Presence', severity: 'warning', message: 'No social profiles (sameAs) — critical for GEO/E-E-A-T signals', fix: 'Add schema.organization.sameAs with social profile URLs' });
+  // FAQPage or HowTo schema (4 pts) — matches aeochecker scoring
+  const hasFaqOrHowTo = config.pages.some(p => {
+    const content = p.content || '';
+    return /^#{1,6}\s+.+\?\s*$/m.test(content) || /^#{1,6}\s+(?:Step\s+\d+[\s:.-]|How\s+to)/im.test(content);
+  });
+  checks.push({ label: 'FAQPage or HowTo schema', passed: hasFaqOrHowTo, points: hasFaqOrHowTo ? 4 : 0 });
+  if (!hasFaqOrHowTo) {
+    suggestions.push('Add FAQ sections (question headings) or step-by-step content to auto-generate FAQPage/HowTo schema');
   }
 
-  // URL is not default (4 pts)
-  const hasRealUrl = config.url !== 'https://example.com' && config.url !== '';
-  checks.push({ label: 'Site URL is configured (not default)', passed: hasRealUrl, points: hasRealUrl ? 4 : 0 });
-  if (!hasRealUrl) {
-    issues.push({ category: 'Schema Presence', severity: 'error', message: 'Site URL is still the default (https://example.com)', fix: 'Set url to your actual site URL' });
+  // Article/WebPage schema (4 pts) — always passes when schema is enabled since defaultType is set
+  const hasArticleOrWebPage = schemaEnabled && (config.schema.defaultType === 'Article' || config.schema.defaultType === 'WebPage');
+  checks.push({ label: 'Article/WebPage schema', passed: hasArticleOrWebPage, points: hasArticleOrWebPage ? 4 : 0 });
+  if (!hasArticleOrWebPage && schemaEnabled) {
+    suggestions.push('Set schema.defaultType to "Article" or "WebPage" for per-page structured data');
   }
 
   return {
@@ -247,13 +250,11 @@ function auditMetaQuality(config: ResolvedAeoConfig, issues: AuditIssue[], sugge
     issues.push({ category: 'Meta Quality', severity: 'warning', message: `Only ${pagesWithTitles.length}/${config.pages.length} pages have titles`, fix: 'Add titles to all pages' });
   }
 
-  // Pages have descriptions (4 pts)
-  const pagesWithDesc = config.pages.filter(p => p.description && p.description.length > 0);
-  const descCoverage = config.pages.length > 0 ? pagesWithDesc.length / config.pages.length : 0;
-  const goodDescCoverage = descCoverage >= 0.5;
-  checks.push({ label: '50%+ of pages have descriptions', passed: goodDescCoverage, points: goodDescCoverage ? 4 : 0 });
-  if (!goodDescCoverage && config.pages.length > 0) {
-    suggestions.push(`Only ${pagesWithDesc.length}/${config.pages.length} pages have descriptions — add per-page descriptions`);
+  // OG image set (4 pts)
+  const hasOgImage = !!config.og.image;
+  checks.push({ label: 'OG image configured', passed: hasOgImage, points: hasOgImage ? 4 : 0 });
+  if (!hasOgImage) {
+    suggestions.push('Set og.image for richer social sharing previews and AI citation cards');
   }
 
   return {

--- a/src/core/generate-wrapper.test.ts
+++ b/src/core/generate-wrapper.test.ts
@@ -7,6 +7,7 @@ import * as rawMarkdown from './raw-markdown';
 import * as manifest from './manifest';
 import * as sitemap from './sitemap';
 import * as aiIndex from './ai-index';
+import * as schema from './schema';
 import type { ResolvedAeoConfig } from '../types';
 
 vi.mock('fs', () => ({
@@ -34,6 +35,7 @@ const baseConfig: ResolvedAeoConfig = {
     manifest: true,
     sitemap: true,
     aiIndex: true,
+    schema: true,
   },
   robots: { allow: ['/'], disallow: [], crawlDelay: 0, sitemap: '' },
   widget: {
@@ -43,6 +45,17 @@ const baseConfig: ResolvedAeoConfig = {
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+  },
+  schema: {
+    enabled: true,
+    organization: { name: 'Test', url: 'https://example.com', logo: '', sameAs: [] },
+    defaultType: 'WebPage',
+  },
+  og: {
+    enabled: false,
+    image: '',
+    twitterHandle: '',
+    type: 'website',
   },
 };
 
@@ -89,6 +102,7 @@ describe('generateAEOFiles', () => {
         manifest: true,
         sitemap: false,
         aiIndex: false,
+        schema: false,
       },
     };
 
@@ -128,6 +142,7 @@ describe('generateAEOFiles', () => {
     vi.spyOn(aiIndex, 'generateAIIndex').mockImplementation(() => { throw new Error('fail'); });
     vi.spyOn(rawMarkdown, 'generatePageMarkdownFiles').mockImplementation(() => { throw new Error('fail'); });
     vi.spyOn(rawMarkdown, 'copyMarkdownFiles').mockImplementation(() => { throw new Error('fail'); });
+    vi.spyOn(schema, 'generateSchema').mockImplementation(() => { throw new Error('fail'); });
 
     const result = await generateAEOFiles(baseConfig);
 

--- a/src/core/llms-full.test.ts
+++ b/src/core/llms-full.test.ts
@@ -24,6 +24,7 @@ const baseConfig: ResolvedAeoConfig = {
     manifest: true,
     sitemap: true,
     aiIndex: true,
+    schema: true,
   },
   robots: { allow: ['/'], disallow: [], crawlDelay: 0, sitemap: '' },
   widget: {
@@ -33,6 +34,17 @@ const baseConfig: ResolvedAeoConfig = {
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+  },
+  schema: {
+    enabled: true,
+    organization: { name: 'Test', url: 'https://example.com', logo: '', sameAs: [] },
+    defaultType: 'WebPage',
+  },
+  og: {
+    enabled: false,
+    image: '',
+    twitterHandle: '',
+    type: 'website',
   },
 };
 

--- a/src/core/llms-txt.test.ts
+++ b/src/core/llms-txt.test.ts
@@ -24,6 +24,7 @@ const baseConfig: ResolvedAeoConfig = {
     manifest: true,
     sitemap: true,
     aiIndex: true,
+    schema: true,
   },
   robots: { allow: ['/'], disallow: [], crawlDelay: 0, sitemap: '' },
   widget: {
@@ -33,6 +34,17 @@ const baseConfig: ResolvedAeoConfig = {
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+  },
+  schema: {
+    enabled: true,
+    organization: { name: 'Test', url: 'https://example.com', logo: '', sameAs: [] },
+    defaultType: 'WebPage',
+  },
+  og: {
+    enabled: false,
+    image: '',
+    twitterHandle: '',
+    type: 'website',
   },
 };
 

--- a/src/core/manifest.test.ts
+++ b/src/core/manifest.test.ts
@@ -29,6 +29,7 @@ const baseConfig: ResolvedAeoConfig = {
     manifest: true,
     sitemap: true,
     aiIndex: true,
+    schema: true,
   },
   robots: { allow: ['/'], disallow: [], crawlDelay: 0, sitemap: '' },
   widget: {
@@ -38,6 +39,17 @@ const baseConfig: ResolvedAeoConfig = {
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+  },
+  schema: {
+    enabled: true,
+    organization: { name: 'Test', url: 'https://example.com', logo: '', sameAs: [] },
+    defaultType: 'WebPage',
+  },
+  og: {
+    enabled: false,
+    image: '',
+    twitterHandle: '',
+    type: 'website',
   },
 };
 

--- a/src/core/opengraph.test.ts
+++ b/src/core/opengraph.test.ts
@@ -10,7 +10,7 @@ function makeConfig(overrides: Partial<ResolvedAeoConfig> = {}): ResolvedAeoConf
     pages: [],
     outDir: './out',
     contentDir: '',
-    generators: { robots: true, llmsTxt: true, llmsFullTxt: true, sitemap: true, aiIndex: true, docs: true, schema: true },
+    generators: { robotsTxt: true, llmsTxt: true, llmsFullTxt: true, rawMarkdown: true, manifest: true, sitemap: true, aiIndex: true, schema: true },
     schema: {
       enabled: true,
       organization: { name: 'Test Org', url: 'https://example.com', logo: '', sameAs: [] },

--- a/src/core/raw-markdown.test.ts
+++ b/src/core/raw-markdown.test.ts
@@ -46,6 +46,7 @@ const createConfig = (overrides = {}): ResolvedAeoConfig => ({
     manifest: true,
     sitemap: true,
     aiIndex: true,
+    schema: true,
   },
   robots: { allow: ['/'], disallow: [], crawlDelay: 0, sitemap: '' },
   widget: {
@@ -55,6 +56,17 @@ const createConfig = (overrides = {}): ResolvedAeoConfig => ({
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+  },
+  schema: {
+    enabled: true,
+    organization: { name: 'Test', url: 'https://example.com', logo: '', sameAs: [] },
+    defaultType: 'WebPage',
+  },
+  og: {
+    enabled: false,
+    image: '',
+    twitterHandle: '',
+    type: 'website',
   },
   ...overrides,
 });

--- a/src/core/robots.test.ts
+++ b/src/core/robots.test.ts
@@ -18,6 +18,7 @@ describe('generateRobotsTxt', () => {
       manifest: true,
       sitemap: true,
       aiIndex: true,
+      schema: true,
     },
     robots: { allow: ['/'], disallow: [], crawlDelay: 0, sitemap: '' },
     widget: {
@@ -27,6 +28,17 @@ describe('generateRobotsTxt', () => {
       humanLabel: 'Human',
       aiLabel: 'AI',
       showBadge: true,
+    },
+    schema: {
+      enabled: true,
+      organization: { name: 'Test', url: 'https://example.com', logo: '', sameAs: [] },
+      defaultType: 'WebPage',
+    },
+    og: {
+      enabled: false,
+      image: '',
+      twitterHandle: '',
+      type: 'website',
     },
   }
 

--- a/src/core/robots.ts
+++ b/src/core/robots.ts
@@ -76,11 +76,20 @@ export function generateRobotsTxt(config: ResolvedAeoConfig): string {
   
   lines.push('# Default for all other bots');
   lines.push('User-agent: *');
-  lines.push('Allow: /');
+  for (const path of (config.robots.allow.length > 0 ? config.robots.allow : ['/'])) {
+    lines.push(`Allow: ${path}`);
+  }
+  for (const path of config.robots.disallow) {
+    lines.push(`Disallow: ${path}`);
+  }
+  if (config.robots.crawlDelay > 0) {
+    lines.push(`Crawl-delay: ${config.robots.crawlDelay}`);
+  }
   lines.push('');
-  
-  if (config.url) {
-    lines.push(`Sitemap: ${config.url}/sitemap.xml`);
+
+  const sitemapUrl = config.robots.sitemap || (config.url ? `${config.url}/sitemap.xml` : '');
+  if (sitemapUrl) {
+    lines.push(`Sitemap: ${sitemapUrl}`);
   }
   
   lines.push('');

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -89,6 +89,24 @@ export function generatePageSchemas(page: PageEntry, config: ResolvedAeoConfig):
     });
   }
 
+  // Detect HowTo patterns (only if no FAQ was detected)
+  if (faqItems.length === 0) {
+    const howToSteps = detectHowToSteps(page.content || '');
+    if (howToSteps.length > 0) {
+      schemas.push({
+        '@context': 'https://schema.org',
+        '@type': 'HowTo',
+        name: page.title || config.title,
+        step: howToSteps.map((s, i) => ({
+          '@type': 'HowToStep',
+          position: i + 1,
+          name: s.name,
+          text: s.text,
+        })),
+      });
+    }
+  }
+
   // WebPage or Article schema
   const pageType = config.schema.defaultType;
   const pageSchema: Record<string, any> = {
@@ -186,14 +204,65 @@ function detectFaqPatterns(content: string): { question: string; answer: string 
 }
 
 /**
+ * Serialize a value to JSON safe for embedding inside HTML <script> tags.
+ * Escapes characters that could break out of the script context.
+ */
+function serializeJsonForHtml(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003C')
+    .replace(/>/g, '\\u003E')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+/**
+ * Detect HowTo step patterns in markdown/text content.
+ * Looks for: numbered step headings (Step 1, Step 2, etc.) or ordered list patterns.
+ */
+function detectHowToSteps(content: string): { name: string; text: string }[] {
+  const steps: { name: string; text: string }[] = [];
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    // Match: ## Step 1: Title, ## 1. Title, ### Step 2 - Title
+    const stepMatch = line.match(/^#{1,6}\s+(?:Step\s+\d+[\s:.-]*|(\d+)[.)]\s*)(.+)$/i);
+    if (stepMatch) {
+      const name = (stepMatch[2] || stepMatch[1] || '').trim();
+      // Collect body text
+      const bodyLines: string[] = [];
+      for (let j = i + 1; j < lines.length; j++) {
+        const nextLine = lines[j].trim();
+        if (!nextLine) {
+          if (bodyLines.length > 0) break;
+          continue;
+        }
+        if (/^#{1,6}\s/.test(nextLine)) break;
+        bodyLines.push(nextLine);
+      }
+      if (name) {
+        steps.push({
+          name,
+          text: bodyLines.join(' ').slice(0, 500),
+        });
+      }
+    }
+  }
+
+  // Only return if we found 2+ steps to avoid false positives
+  return steps.length >= 2 ? steps : [];
+}
+
+/**
  * Generate a JSON-LD script tag string for injection into HTML.
  */
 export function generateJsonLdScript(schemas: object[]): string {
   if (schemas.length === 0) return '';
   if (schemas.length === 1) {
-    return `<script type="application/ld+json">${JSON.stringify(schemas[0])}</script>`;
+    return `<script type="application/ld+json">${serializeJsonForHtml(schemas[0])}</script>`;
   }
   return schemas
-    .map(s => `<script type="application/ld+json">${JSON.stringify(s)}</script>`)
+    .map(s => `<script type="application/ld+json">${serializeJsonForHtml(s)}</script>`)
     .join('\n');
 }

--- a/src/core/sitemap.test.ts
+++ b/src/core/sitemap.test.ts
@@ -47,6 +47,7 @@ describe('generateSitemap', () => {
       manifest: true,
       sitemap: true,
       aiIndex: true,
+      schema: true,
     },
     robots: { allow: ['/'], disallow: [], crawlDelay: 0, sitemap: '' },
     widget: {
@@ -56,6 +57,17 @@ describe('generateSitemap', () => {
       humanLabel: 'Human',
       aiLabel: 'AI',
       showBadge: true,
+    },
+    schema: {
+      enabled: true,
+      organization: { name: 'Test', url: 'https://example.com', logo: '', sameAs: [] },
+      defaultType: 'WebPage',
+    },
+    og: {
+      enabled: false,
+      image: '',
+      twitterHandle: '',
+      type: 'website',
     },
   };
 

--- a/src/plugins/astro.ts
+++ b/src/plugins/astro.ts
@@ -318,8 +318,10 @@ if (!document.querySelector('meta[name="astro-view-transitions-enabled"]')) {
           let pagePath = req.url.replace(/\.md$/, '') || '/';
           if (pagePath === '/index') pagePath = '/';
           try {
-            const host = req.headers.host || 'localhost:4321';
-            const protocol = req.connection?.encrypted ? 'https' : 'http';
+            const rawHost = req.headers.host || 'localhost:4321';
+            // Only allow localhost/127.0.0.1 to prevent SSRF via forged Host headers
+            const host = /^(localhost|127\.0\.0\.1)(:\d+)?$/.test(rawHost) ? rawHost : 'localhost:4321';
+            const protocol = 'http';
             const response = await fetch(`${protocol}://${host}${pagePath}`, {
               headers: { 'x-aeo-internal': '1' },
             });

--- a/src/plugins/vite.ts
+++ b/src/plugins/vite.ts
@@ -1,7 +1,7 @@
 import { generateAEOFiles } from '../core/generate';
 import { resolveConfig } from '../core/utils';
 import { extractTextFromHtml, extractTitle, extractDescription, htmlToMarkdown } from '../core/html-extract';
-import { generatePageSchemas, generateJsonLdScript } from '../core/schema';
+import { generatePageSchemas, generateSiteSchemas, generateJsonLdScript } from '../core/schema';
 import { generateOGTagsHtml } from '../core/opengraph';
 import type { AeoConfig, PageEntry } from '../types';
 import { join, dirname } from 'path';
@@ -107,8 +107,10 @@ export function aeoVitePlugin(options: AeoConfig = {}): any {
         let pagePath = req.url.replace(/\.md$/, '') || '/';
         if (pagePath === '/index') pagePath = '/';
         try {
-          const host = req.headers.host || 'localhost:5173';
-          const protocol = req.connection?.encrypted ? 'https' : 'http';
+          const rawHost = req.headers.host || 'localhost:5173';
+          // Only allow localhost/127.0.0.1 to prevent SSRF via forged Host headers
+          const host = /^(localhost|127\.0\.0\.1)(:\d+)?$/.test(rawHost) ? rawHost : 'localhost:5173';
+          const protocol = 'http';
           const response = await fetch(`${protocol}://${host}${pagePath}`, {
             headers: { 'x-aeo-internal': '1' },
           });
@@ -243,6 +245,23 @@ if (typeof window !== 'undefined') {
           content: extractTextFromHtml(html),
         };
 
+        // Inject canonical URL if not present
+        if (!/rel=["']canonical["']/i.test(result)) {
+          const canonicalUrl = pagePath === '/'
+            ? resolvedConfig.url
+            : `${resolvedConfig.url.replace(/\/$/, '')}${pagePath}`;
+          result = result.replace('</head>', `    <link rel="canonical" href="${canonicalUrl}" />\n</head>`);
+        }
+
+        // Inject meta description if not present
+        if (!/name=["']description["']/i.test(result)) {
+          const desc = pageEntry.description || resolvedConfig.description;
+          if (desc) {
+            const escDesc = desc.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            result = result.replace('</head>', `    <meta name="description" content="${escDesc}" />\n</head>`);
+          }
+        }
+
         // Inject OG meta tags
         if (resolvedConfig.og.enabled) {
           const ogHtml = generateOGTagsHtml(pageEntry, resolvedConfig);
@@ -251,8 +270,9 @@ if (typeof window !== 'undefined') {
 
         // Inject JSON-LD structured data
         if (resolvedConfig.schema.enabled) {
-          const schemas = generatePageSchemas(pageEntry, resolvedConfig);
-          const jsonLd = generateJsonLdScript(schemas);
+          const siteSchemas = generateSiteSchemas(resolvedConfig);
+          const pageSchemas = generatePageSchemas(pageEntry, resolvedConfig);
+          const jsonLd = generateJsonLdScript([...siteSchemas, ...pageSchemas]);
           if (jsonLd) {
             result = result.replace('</head>', `    ${jsonLd}\n</head>`);
           }


### PR DESCRIPTION
## Score improvements (up to +12 pts on aeochecker)

| Fix | Category | Points |
|-----|----------|--------|
| Canonical URL injection in Vite plugin | Meta Quality | +4 |
| Site-level schemas (Organization/WebSite) injected into page HTML | Schema Presence | +4 |
| HowTo schema auto-detection for step-by-step content | Schema Presence | +4 |
| Meta description fallback when missing | Meta Quality | indirect |

## Security fixes

- **JSON-LD XSS** — `generateJsonLdScript` now escapes `<`, `>`, `&`, and Unicode line separators before injecting into `<script>` tags
- **SSRF in dev middleware** — Vite and Astro plugins now validate `Host` header against localhost only

## Correctness

- **robots.txt respects user config** — `allow`, `disallow`, `crawlDelay`, and `sitemap` from config are now used
- **Local audit aligned with aeochecker** — Schema Presence checks now match aeochecker criteria (JSON-LD, Org name, Org logo, FAQPage/HowTo, Article/WebPage)
- Fixed pre-existing TS errors in test fixtures