### PR TITLE
feat: add small size option for widget toggle

### DIFF
--- a/src/core/ai-index.test.ts
+++ b/src/core/ai-index.test.ts
@@ -37,6 +37,7 @@ const baseConfig: ResolvedAeoConfig = {
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+    size: 'default' as const,
   },
 };
 

--- a/src/core/audit.test.ts
+++ b/src/core/audit.test.ts
@@ -18,7 +18,7 @@ function makeConfig(overrides: Partial<ResolvedAeoConfig> = {}): ResolvedAeoConf
       defaultType: 'WebPage',
     },
     og: { enabled: true, image: 'https://example.com/og.png', twitterHandle: '@test', type: 'website' },
-    widget: { enabled: false, position: 'bottom-right', theme: { background: '', text: '', accent: '', badge: '' }, humanLabel: '', aiLabel: '', showBadge: false },
+    widget: { enabled: false, position: 'bottom-right', size: 'default' as const, theme: { background: '', text: '', accent: '', badge: '' }, humanLabel: '', aiLabel: '', showBadge: false },
     ...overrides,
   } as ResolvedAeoConfig;
 }

--- a/src/core/generate-wrapper.test.ts
+++ b/src/core/generate-wrapper.test.ts
@@ -43,6 +43,7 @@ const baseConfig: ResolvedAeoConfig = {
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+    size: 'default' as const,
   },
 };
 

--- a/src/core/llms-full.test.ts
+++ b/src/core/llms-full.test.ts
@@ -33,6 +33,7 @@ const baseConfig: ResolvedAeoConfig = {
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+    size: 'default' as const,
   },
 };
 

--- a/src/core/llms-txt.test.ts
+++ b/src/core/llms-txt.test.ts
@@ -33,6 +33,7 @@ const baseConfig: ResolvedAeoConfig = {
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+    size: 'default' as const,
   },
 };
 

--- a/src/core/manifest.test.ts
+++ b/src/core/manifest.test.ts
@@ -38,6 +38,7 @@ const baseConfig: ResolvedAeoConfig = {
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+    size: 'default' as const,
   },
 };
 

--- a/src/core/raw-markdown.test.ts
+++ b/src/core/raw-markdown.test.ts
@@ -55,6 +55,7 @@ const createConfig = (overrides = {}): ResolvedAeoConfig => ({
     humanLabel: 'Human',
     aiLabel: 'AI',
     showBadge: true,
+    size: 'default' as const,
   },
   ...overrides,
 });

--- a/src/core/report.test.ts
+++ b/src/core/report.test.ts
@@ -17,7 +17,7 @@ function makeConfig(): ResolvedAeoConfig {
     robots: { allow: ['/'], disallow: [], crawlDelay: 0, sitemap: '/sitemap.xml' },
     schema: { enabled: true, organization: { name: 'Test Co', url: 'https://test.com', logo: '', sameAs: [] }, defaultType: 'WebPage' },
     og: { enabled: true, image: '', twitterHandle: '', type: 'website' },
-    widget: { enabled: false, position: 'bottom-right', theme: { background: '', text: '', accent: '', badge: '' }, humanLabel: '', aiLabel: '', showBadge: false },
+    widget: { enabled: false, position: 'bottom-right', size: 'default' as const, theme: { background: '', text: '', accent: '', badge: '' }, humanLabel: '', aiLabel: '', showBadge: false },
   } as ResolvedAeoConfig;
 }
 

--- a/src/core/robots.test.ts
+++ b/src/core/robots.test.ts
@@ -27,6 +27,7 @@ describe('generateRobotsTxt', () => {
       humanLabel: 'Human',
       aiLabel: 'AI',
       showBadge: true,
+      size: 'default' as const,
     },
   }
 

--- a/src/core/sitemap.test.ts
+++ b/src/core/sitemap.test.ts
@@ -56,6 +56,7 @@ describe('generateSitemap', () => {
       humanLabel: 'Human',
       aiLabel: 'AI',
       showBadge: true,
+      size: 'default' as const,
     },
   };
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -71,6 +71,7 @@ export function resolveConfig(config: AeoConfig = {}): ResolvedAeoConfig {
     widget: {
       enabled: config.widget?.enabled !== false,
       position: config.widget?.position || 'bottom-right',
+      size: config.widget?.size || 'default',
       theme: {
         background: config.widget?.theme?.background || 'rgba(18, 18, 24, 0.9)',
         text: config.widget?.theme?.text || '#C0C0C5',

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface AeoConfig {
   widget?: {
     enabled?: boolean;
     position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
+    size?: 'default' | 'small';
     theme?: {
       background?: string;
       text?: string;
@@ -101,6 +102,7 @@ export interface ResolvedAeoConfig {
   widget: {
     enabled: boolean;
     position: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
+    size: 'default' | 'small';
     theme: {
       background: string;
       text: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export interface AeoConfig {
   widget?: {
     enabled?: boolean;
     position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
-    size?: 'default' | 'small';
+    size?: 'default' | 'small' | 'icon-only';
     theme?: {
       background?: string;
       text?: string;
@@ -102,7 +102,7 @@ export interface ResolvedAeoConfig {
   widget: {
     enabled: boolean;
     position: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
-    size: 'default' | 'small';
+    size: 'default' | 'small' | 'icon-only';
     theme: {
       background: string;
       text: string;

--- a/src/widget/core.ts
+++ b/src/widget/core.ts
@@ -69,16 +69,17 @@ export class AeoWidget {
     if (this.styleElement) return;
 
     this.styleElement = document.createElement('style');
-    this.styleElement.textContent = getStyles(this.config.widget?.theme);
+    this.styleElement.textContent = getStyles(this.config.widget?.theme, this.config.widget?.size);
     document.head.appendChild(this.styleElement);
   }
 
   private createToggle(): void {
     const position = this.config.widget?.position || 'bottom-right';
+    const size = this.config.widget?.size || 'default';
     const icons = getIcons();
 
     this.toggleElement = document.createElement('div');
-    this.toggleElement.className = `aeo-toggle aeo-${position}`;
+    this.toggleElement.className = `aeo-toggle aeo-${position}${size === 'small' ? ' aeo-small' : ''}`;
     this.toggleElement.innerHTML = `
       <div class="aeo-toggle-inner">
         <button class="aeo-toggle-btn aeo-human-btn aeo-active" data-mode="human">

--- a/src/widget/core.ts
+++ b/src/widget/core.ts
@@ -79,7 +79,8 @@ export class AeoWidget {
     const icons = getIcons();
 
     this.toggleElement = document.createElement('div');
-    this.toggleElement.className = `aeo-toggle aeo-${position}${size === 'small' ? ' aeo-small' : ''}`;
+    const sizeClass = size === 'small' ? ' aeo-small' : size === 'icon-only' ? ' aeo-icon-only' : '';
+    this.toggleElement.className = `aeo-toggle aeo-${position}${sizeClass}`;
     this.toggleElement.innerHTML = `
       <div class="aeo-toggle-inner">
         <button class="aeo-toggle-btn aeo-human-btn aeo-active" data-mode="human">

--- a/src/widget/styles.ts
+++ b/src/widget/styles.ts
@@ -5,7 +5,7 @@ export interface ThemeConfig {
   badge?: string;
 }
 
-export function getStyles(theme?: ThemeConfig): string {
+export function getStyles(theme?: ThemeConfig, size?: 'default' | 'small'): string {
   const t = {
     background: theme?.background || '#0a0a0f',
     text: theme?.text || '#a0a0a8',
@@ -622,6 +622,28 @@ export function getStyles(theme?: ThemeConfig): string {
         animation: none;
         transition: none;
       }
+    }
+
+    /* Small size variant */
+    .aeo-toggle.aeo-small {
+      font-size: 11px;
+    }
+
+    .aeo-toggle.aeo-small .aeo-toggle-inner {
+      border-radius: 18px;
+      padding: 3px;
+    }
+
+    .aeo-toggle.aeo-small .aeo-toggle-btn {
+      gap: 5px;
+      padding: 5px 10px;
+      font-size: 11px;
+      border-radius: 15px;
+    }
+
+    .aeo-toggle.aeo-small .aeo-toggle-btn svg {
+      width: 12px;
+      height: 12px;
     }
   `.trim();
 }

--- a/src/widget/styles.ts
+++ b/src/widget/styles.ts
@@ -5,7 +5,7 @@ export interface ThemeConfig {
   badge?: string;
 }
 
-export function getStyles(theme?: ThemeConfig, size?: 'default' | 'small'): string {
+export function getStyles(theme?: ThemeConfig, size?: 'default' | 'small' | 'icon-only'): string {
   const t = {
     background: theme?.background || '#0a0a0f',
     text: theme?.text || '#a0a0a8',
@@ -644,6 +644,27 @@ export function getStyles(theme?: ThemeConfig, size?: 'default' | 'small'): stri
     .aeo-toggle.aeo-small .aeo-toggle-btn svg {
       width: 12px;
       height: 12px;
+    }
+
+    /* Icon-only variant */
+    .aeo-toggle.aeo-icon-only .aeo-toggle-inner {
+      border-radius: 18px;
+      padding: 3px;
+    }
+
+    .aeo-toggle.aeo-icon-only .aeo-toggle-btn {
+      padding: 6px;
+      border-radius: 15px;
+      gap: 0;
+    }
+
+    .aeo-toggle.aeo-icon-only .aeo-toggle-btn span {
+      display: none;
+    }
+
+    .aeo-toggle.aeo-icon-only .aeo-toggle-btn svg {
+      width: 14px;
+      height: 14px;
     }
   `.trim();
 }


### PR DESCRIPTION
Adds a `widget.size` config option (`'default' | 'small'`) for a compact toggle pill.

### Usage
```ts
aeoVitePlugin({
  widget: { size: 'small' }
})
```

### What changes
| Property | Default | Small |
|----------|---------|-------|
| Font size | 14px | 11px |
| Padding | 8px 16px | 5px 10px |
| Icons | 16px | 12px |
| Border radius | 24px | 18px |

The overlay (full-screen markdown view) stays the same size.