### PR TITLE
feat(website): redesign landing page with glassmorphic dark theme

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -10,9 +10,21 @@ export default defineConfig({
 			title: 'aeo.js',
 			description: 'Answer Engine Optimization for the modern web. Make your site discoverable by AI crawlers and LLMs.',
 			url: 'https://aeojs.org',
+			schema: {
+				organization: {
+					name: 'aeo.js',
+					url: 'https://aeojs.org',
+					logo: 'https://aeojs.org/og.png',
+					sameAs: [
+						'https://github.com/multivmlabs/aeo.js',
+						'https://www.npmjs.com/package/aeo.js',
+					],
+				},
+			},
 			widget: {
 				enabled: true,
 				position: 'bottom-right',
+				size: 'small',
 				showBadge: true,
 				theme: {
 					background: 'rgba(10, 10, 10, 0.95)',
@@ -25,12 +37,11 @@ export default defineConfig({
 		starlight({
 			title: 'aeo.js',
 			description: 'Answer Engine Optimization for the modern web. Make your site discoverable by AI crawlers and LLMs.',
-			social: [
-				{ icon: 'github', label: 'GitHub', href: 'https://github.com/multivmlabs/aeo.js' },
-				{ icon: 'npm', label: 'npm', href: 'https://www.npmjs.com/package/aeo.js' },
-			],
+			social: [],
 			components: {
 				Header: './src/components/Header.astro',
+				Hero: './src/components/Hero.astro',
+				Footer: './src/components/Footer.astro',
 			},
 			customCss: ['./src/styles/custom.css'],
 			head: [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/starlight": "^0.38.1",
+        "aeo.js": "^0.0.8",
         "astro": "^6.0.1",
         "sharp": "^0.34.2"
       }
@@ -1911,6 +1912,12 @@
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
       "license": "MIT"
     },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "license": "MIT"
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -1975,6 +1982,52 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/aeo.js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/aeo.js/-/aeo.js-0.0.8.tgz",
+      "integrity": "sha512-WZmc0V9kv58kcSnp6UlAYrhz2xvpqsoQRsHHYFlZKmPMMWzXdbSJK47nI3JnVV7jo1nK316QkPzhk2yJi6P0YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^5.1.2",
+        "minimatch": "^10.2.2"
+      },
+      "bin": {
+        "aeo.js": "dist/cli.mjs",
+        "aeojs": "dist/cli.mjs"
+      },
+      "peerDependencies": {
+        "@astrojs/astro": ">=3.0.0",
+        "@nuxt/kit": ">=3.0.0",
+        "next": ">=13.0.0",
+        "react": ">=17.0.0",
+        "vite": ">=4.0.0",
+        "vue": ">=3.0.0",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/astro": {
+          "optional": true
+        },
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/anymatch": {
@@ -2151,6 +2204,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/bcp-47": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
@@ -2181,6 +2243,18 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -4609,6 +4683,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38.1",
-    "aeo.js": "^0.0.7",
+    "aeo.js": "^0.0.8",
     "astro": "^6.0.1",
     "sharp": "^0.34.2"
   }

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,0 +1,52 @@
+---
+import Default from '@astrojs/starlight/components/Footer.astro';
+---
+
+<Default {...Astro.props}><slot /></Default>
+
+<footer class="aeo-footer">
+  <span>Built by</span>
+  <a href="https://github.com/rubenmarcus" target="_blank" rel="noopener">rubenmarcus</a>
+  <span class="sep">&</span>
+  <a href="https://github.com/multivmlabs" target="_blank" rel="noopener">multivmlabs</a>
+</footer>
+
+<style>
+  .aeo-footer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 1.5rem 1rem;
+    font-size: 0.78rem;
+    color: rgba(255, 255, 255, 0.25);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .aeo-footer a {
+    color: rgba(255, 255, 255, 0.45);
+    text-decoration: none;
+    transition: color 0.15s ease;
+  }
+
+  .aeo-footer a:hover {
+    color: #fff;
+  }
+
+  .sep {
+    opacity: 0.4;
+  }
+
+  :global([data-theme="light"]) .aeo-footer {
+    color: rgba(0, 0, 0, 0.3);
+    border-top-color: rgba(0, 0, 0, 0.06);
+  }
+
+  :global([data-theme="light"]) .aeo-footer a {
+    color: rgba(0, 0, 0, 0.5);
+  }
+
+  :global([data-theme="light"]) .aeo-footer a:hover {
+    color: #000;
+  }
+</style>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -1,81 +1,152 @@
 ---
-import Default from '@astrojs/starlight/components/Header.astro';
+import config from 'virtual:starlight/user-config';
+import Search from 'virtual:starlight/components/Search';
+import SiteTitle from 'virtual:starlight/components/SiteTitle';
+
+const shouldRenderSearch =
+	config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 ---
 
-<Default {...Astro.props}><slot /></Default>
+<div class="header">
+  <div class="header-left">
+    <div class="title-wrapper sl-flex">
+      <SiteTitle />
+    </div>
+    <nav class="header-nav">
+      <a href="/getting-started/introduction/" class="header-link">Docs</a>
+      <a href="https://check.aeojs.org" target="_blank" rel="noopener" class="header-link">Checker</a>
+    </nav>
+  </div>
 
-<nav class="custom-header-links">
-  <a href="/getting-started/introduction/" class="header-link">Docs</a>
-  <a href="https://github.com/multivmlabs/aeo.js" target="_blank" rel="noopener" class="header-star-btn">
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-    Star on GitHub
-  </a>
-</nav>
+  <div class="header-center sl-flex print:hidden">
+    {shouldRenderSearch && <Search />}
+  </div>
+
+  <div class="header-right">
+    <a href="https://www.npmjs.com/package/aeo.js" target="_blank" rel="noopener" class="header-badge" aria-label="npm downloads">
+      <img src="https://img.shields.io/npm/dm/aeo.js?style=flat&colorA=0d0d0d&colorB=1a1a1a&label=downloads" alt="npm downloads" loading="lazy" />
+    </a>
+    <a href="https://github.com/multivmlabs/aeo.js" target="_blank" rel="noopener" class="header-badge" aria-label="GitHub stars">
+      <img src="https://img.shields.io/github/stars/multivmlabs/aeo.js?style=flat&colorA=0d0d0d&colorB=1a1a1a&label=stars" alt="GitHub stars" loading="lazy" />
+    </a>
+    <a
+      href="https://github.com/multivmlabs/aeo.js"
+      target="_blank"
+      rel="noopener"
+      class="header-github"
+      aria-label="GitHub"
+    >
+      <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor">
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+      </svg>
+    </a>
+  </div>
+</div>
 
 <style>
-  .custom-header-links {
+  .header {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    position: absolute;
-    right: calc(var(--sl-nav-pad-x, 1rem) + 5rem);
-    top: 50%;
-    transform: translateY(-50%);
+    gap: 1rem;
+    height: 100%;
+    max-width: 72rem;
+    margin-inline: auto;
+    width: 100%;
+  }
+
+  .header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex-shrink: 0;
+  }
+
+  .title-wrapper {
+    overflow: clip;
+    padding: 0.25rem;
+    margin: -0.25rem;
+    min-width: 0;
+  }
+
+  .header-nav {
+    display: none;
+    align-items: center;
+    gap: 0;
+    margin-left: 0.5rem;
   }
 
   .header-link {
     display: inline-flex;
     align-items: center;
-    padding: 0.35rem 0.85rem;
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: var(--sl-color-gray-2);
+    padding: 0.3rem 0.6rem;
+    font-size: 0.8rem;
+    font-weight: 450;
+    color: rgba(255, 255, 255, 0.4);
     text-decoration: none;
-    border-radius: 8px;
-    transition: color 0.2s ease, background 0.2s ease;
+    border-radius: 6px;
+    transition: color 0.15s ease;
+    letter-spacing: -0.01em;
   }
 
   .header-link:hover {
-    color: var(--sl-color-white);
-    background: rgba(255, 255, 255, 0.06);
+    color: #fff;
   }
 
-  .header-star-btn {
+  .header-center {
+    flex: 1;
+    justify-content: center;
+    min-width: 0;
+  }
+
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  .header-badge {
+    display: none;
+    align-items: center;
+    border-radius: 4px;
+    overflow: hidden;
+    opacity: 0.7;
+    transition: opacity 0.15s ease;
+    line-height: 0;
+  }
+
+  .header-badge:hover {
+    opacity: 1;
+  }
+
+  .header-badge img {
+    height: 20px;
+    display: block;
+  }
+
+  .header-github {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
-    padding: 0.35rem 0.85rem;
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: #000;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    color: rgba(255, 255, 255, 0.4);
     text-decoration: none;
-    border-radius: 8px;
-    background: #fff;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    transition: all 0.2s ease;
-    box-shadow: 0 0 12px rgba(255, 255, 255, 0.08);
-    white-space: nowrap;
+    border-radius: 6px;
+    transition: color 0.15s ease;
   }
 
-  .header-star-btn:hover {
-    box-shadow: 0 0 20px rgba(255, 255, 255, 0.14);
-    transform: translateY(-1px);
-  }
-
-  :global([data-theme="light"]) .header-link:hover {
-    background: rgba(0, 0, 0, 0.05);
-  }
-
-  :global([data-theme="light"]) .header-star-btn {
-    background: #000;
+  .header-github:hover {
     color: #fff;
-    border-color: #000;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   }
 
-  @media (max-width: 50rem) {
-    .custom-header-links {
-      display: none;
+  @media (min-width: 50rem) {
+    .header-nav {
+      display: flex;
+    }
+
+    .header-badge {
+      display: inline-flex;
     }
   }
 </style>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -1,0 +1,168 @@
+---
+import { Image } from 'astro:assets';
+import Terminal from './Terminal.astro';
+
+const PAGE_TITLE_ID = '_top';
+
+const { data } = Astro.locals.starlightRoute.entry;
+const { title = data.title, tagline, image, actions = [] } = data.hero || {};
+
+const imageAttrs = {
+	loading: 'eager' as const,
+	decoding: 'async' as const,
+	width: 400,
+	height: 400,
+	alt: image?.alt || '',
+};
+
+let darkImage: ImageMetadata | undefined;
+let lightImage: ImageMetadata | undefined;
+let rawHtml: string | undefined;
+if (image) {
+	if ('file' in image) {
+		darkImage = image.file;
+	} else if ('dark' in image) {
+		darkImage = image.dark;
+		lightImage = image.light;
+	} else {
+		rawHtml = image.html;
+	}
+}
+
+const isSplash = data.template === 'splash';
+---
+
+<div class="hero">
+	{
+		darkImage && (
+			<Image
+				src={darkImage}
+				{...imageAttrs}
+				class:list={{ 'light:sl-hidden': Boolean(lightImage) }}
+			/>
+		)
+	}
+	{lightImage && <Image src={lightImage} {...imageAttrs} class="dark:sl-hidden" />}
+	{rawHtml && <div class="hero-html sl-flex" set:html={rawHtml} />}
+	<div class="sl-flex stack">
+		<div class="sl-flex copy">
+			<h1 id={PAGE_TITLE_ID} data-page-title set:html={title} />
+			{tagline && <div class="tagline" id="hero-tagline" data-text={tagline}></div>}
+		</div>
+		{
+			actions.length > 0 && (
+				<div class="sl-flex actions">
+					{actions.map(({ icon, link: href, text, variant }) => (
+						<a href={href} class:list={['sl-link-button', 'action', variant || 'primary']}>
+							{text}
+							<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+						</a>
+					))}
+				</div>
+			)
+		}
+	</div>
+	{isSplash && <div class="hero-terminal-wrap"><Terminal /></div>}
+</div>
+
+<script>
+	function typeTagline() {
+		const el = document.getElementById('hero-tagline');
+		if (!el) return;
+		const text = el.dataset.text || '';
+		if (el.textContent === text) return;
+		el.textContent = '';
+		el.style.opacity = '1';
+		let i = 0;
+		const interval = setInterval(() => {
+			el.textContent += text[i];
+			i++;
+			if (i >= text.length) clearInterval(interval);
+		}, 28);
+	}
+	document.addEventListener('DOMContentLoaded', typeTagline);
+	document.addEventListener('astro:page-load', typeTagline);
+</script>
+
+<style>
+	@layer starlight.core {
+		.hero {
+			display: grid;
+			align-items: center;
+			gap: 1rem;
+			padding-bottom: 1rem;
+		}
+
+		.hero > img,
+		.hero > .hero-html {
+			object-fit: contain;
+			width: min(70%, 20rem);
+			height: auto;
+			margin-inline: auto;
+		}
+
+		.stack {
+			flex-direction: column;
+			gap: clamp(1.5rem, calc(1.5rem + 1vw), 2rem);
+			text-align: center;
+		}
+
+		.copy {
+			flex-direction: column;
+			gap: 1rem;
+			align-items: center;
+		}
+
+		.copy > * {
+			max-width: 50ch;
+		}
+
+		h1 {
+			font-size: clamp(var(--sl-text-3xl), calc(0.25rem + 5vw), var(--sl-text-6xl));
+			line-height: var(--sl-line-height-headings);
+			font-weight: 600;
+			color: var(--sl-color-white);
+		}
+
+		.tagline {
+			font-size: clamp(var(--sl-text-base), calc(0.0625rem + 2vw), var(--sl-text-xl));
+			color: var(--sl-color-gray-2);
+		}
+
+		.actions {
+			gap: 1rem 2rem;
+			flex-wrap: wrap;
+			justify-content: center;
+		}
+
+		@media (min-width: 50rem) {
+			.hero {
+				grid-template-columns: 1fr 1fr;
+				gap: 3rem;
+				padding-block: clamp(2.5rem, calc(1rem + 10vmin), 10rem);
+			}
+
+			.hero > img,
+			.hero > .hero-html {
+				order: 2;
+				width: min(100%, 25rem);
+			}
+
+			.stack {
+				text-align: start;
+			}
+
+			.copy {
+				align-items: flex-start;
+			}
+
+			.actions {
+				justify-content: flex-start;
+			}
+		}
+	}
+
+	.hero-terminal-wrap {
+		display: block;
+	}
+</style>

--- a/website/src/components/StickyNav.astro
+++ b/website/src/components/StickyNav.astro
@@ -1,0 +1,141 @@
+---
+const sections = [
+  { label: 'Quick Start', id: 'quick-start' },
+  { label: 'What is AEO?', id: 'what-is-aeo' },
+  { label: 'Why AEO', id: 'why-aeo-matters' },
+  { label: 'Widget', id: 'widget' },
+  { label: 'Configuration', id: 'configuration' },
+  { label: 'Generated Files', id: 'generated-files' },
+  { label: 'Checker', id: 'checker' },
+];
+---
+
+<nav class="sticky-nav" id="sticky-nav" aria-label="Page sections">
+  <ul>
+    {sections.map(({ label, id }) => (
+      <li>
+        <a href={`#${id}`} data-section={id}>
+          <span class="dot"></span>
+          <span class="label">{label}</span>
+        </a>
+      </li>
+    ))}
+  </ul>
+</nav>
+
+<script>
+  function initStickyNav() {
+    const nav = document.getElementById('sticky-nav');
+    if (!nav) return;
+
+    const links = nav.querySelectorAll('a[data-section]');
+    const sectionIds = Array.from(links).map(l => (l as HTMLElement).dataset.section!);
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            links.forEach(l => l.classList.remove('active'));
+            const active = nav.querySelector(`a[data-section="${entry.target.id}"]`);
+            active?.classList.add('active');
+          }
+        });
+      },
+      { rootMargin: '-20% 0px -60% 0px' }
+    );
+
+    sectionIds.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', initStickyNav);
+  document.addEventListener('astro:page-load', initStickyNav);
+</script>
+
+<style>
+  .sticky-nav {
+    position: fixed;
+    right: 1.25rem;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 40;
+    padding: 0.75rem 0.85rem;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0.01) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  a {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.5rem;
+    text-decoration: none;
+    justify-content: flex-end;
+    border-radius: 6px;
+    transition: all 0.15s ease;
+  }
+
+  a:hover {
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .label {
+    font-size: 0.65rem;
+    font-weight: 450;
+    color: rgba(255, 255, 255, 0.4);
+    letter-spacing: 0.01em;
+    transition: color 0.15s ease;
+    white-space: nowrap;
+  }
+
+  .dot {
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.2);
+    flex-shrink: 0;
+    transition: all 0.2s ease;
+  }
+
+  a:hover .label {
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  a:hover .dot {
+    background: rgba(255, 255, 255, 0.5);
+  }
+
+  a.active {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  a.active .dot {
+    background: #fff;
+    box-shadow: 0 0 4px rgba(255, 255, 255, 0.4);
+  }
+
+  a.active .label {
+    color: #fff;
+    font-weight: 500;
+  }
+
+  @media (max-width: 72rem) {
+    .sticky-nav {
+      display: none;
+    }
+  }
+</style>

--- a/website/src/components/Terminal.astro
+++ b/website/src/components/Terminal.astro
@@ -1,0 +1,329 @@
+---
+---
+
+<div class="terminal" id="hero-terminal">
+  <div class="terminal-header">
+    <div class="terminal-dots">
+      <span class="dot dot-red"></span>
+      <span class="dot dot-yellow"></span>
+      <span class="dot dot-green"></span>
+    </div>
+    <div class="terminal-tabs">
+      <button class="terminal-tab active" data-tab="install">Install</button>
+      <button class="terminal-tab" data-tab="audit">Audit</button>
+      <button class="terminal-tab" data-tab="generate">Generate</button>
+      <button class="terminal-tab" data-tab="config">Config</button>
+    </div>
+  </div>
+  <div class="terminal-body">
+    <div class="terminal-panel active" id="panel-install">
+      <div class="terminal-line">
+        <span class="t-prompt">$</span>
+        <span class="t-cmd" id="cmd-install"></span><span class="t-cursor">▌</span>
+      </div>
+      <div class="terminal-output" id="out-install">
+        <div class="t-dim">added 1 package in 2s</div>
+        <br/>
+        <div><span class="t-green">✓</span> <span class="t-dim">Ready — run</span> <span class="t-white">npx aeo.js init</span> <span class="t-dim">to get started</span></div>
+      </div>
+    </div>
+
+    <div class="terminal-panel" id="panel-audit">
+      <div class="terminal-line">
+        <span class="t-prompt">$</span>
+        <span class="t-cmd" id="cmd-audit"></span><span class="t-cursor">▌</span>
+      </div>
+      <div class="terminal-output" id="out-audit">
+        <br/>
+        <div class="t-white">GEO Readiness Score: 92/100 (Excellent)</div>
+        <div class="t-dim">══════════════════════════════════════</div>
+        <br/>
+        <div><span class="t-green">✓</span> <span class="t-dim">AI Access:</span> <span class="t-white">20/20</span></div>
+        <div><span class="t-green">✓</span> <span class="t-dim">Content Structure:</span> <span class="t-white">20/20</span></div>
+        <div><span class="t-green">✓</span> <span class="t-dim">Schema Presence:</span> <span class="t-white">20/20</span></div>
+        <div><span class="t-green">✓</span> <span class="t-dim">Meta Quality:</span> <span class="t-white">16/20</span></div>
+        <div><span class="t-green">✓</span> <span class="t-dim">Citability:</span> <span class="t-white">16/20</span></div>
+      </div>
+    </div>
+
+    <div class="terminal-panel" id="panel-generate">
+      <div class="terminal-line">
+        <span class="t-prompt">$</span>
+        <span class="t-cmd" id="cmd-generate"></span><span class="t-cursor">▌</span>
+      </div>
+      <div class="terminal-output" id="out-generate">
+        <br/>
+        <div class="t-dim">[aeo.js] Generating AEO files...</div>
+        <div><span class="t-green">✓</span> <span class="t-white">robots.txt</span> <span class="t-dim">— AI crawler directives</span></div>
+        <div><span class="t-green">✓</span> <span class="t-white">llms.txt</span> <span class="t-dim">— LLM summary</span></div>
+        <div><span class="t-green">✓</span> <span class="t-white">llms-full.txt</span> <span class="t-dim">— full content for LLMs</span></div>
+        <div><span class="t-green">✓</span> <span class="t-white">sitemap.xml</span> <span class="t-dim">— sitemap</span></div>
+        <div><span class="t-green">✓</span> <span class="t-white">schema.json</span> <span class="t-dim">— JSON-LD structured data</span></div>
+        <div><span class="t-green">✓</span> <span class="t-white">ai-index.json</span> <span class="t-dim">— AI content index</span></div>
+        <br/>
+        <div class="t-dim">Generated <span class="t-white">6 files</span> in 42ms</div>
+      </div>
+    </div>
+
+    <div class="terminal-panel" id="panel-config">
+      <div class="terminal-line">
+        <span class="t-dim">// aeo.config.ts</span>
+      </div>
+      <div class="terminal-output terminal-output-visible">
+        <div><span class="t-purple">import</span> <span class="t-white">{"{ defineConfig }"}</span> <span class="t-purple">from</span> <span class="t-str">'aeo.js'</span></div>
+        <br/>
+        <div><span class="t-purple">export default</span> <span class="t-white">{"defineConfig({"}</span></div>
+        <div><span class="t-white">{"  title: "}</span><span class="t-str">'My Site'</span><span class="t-white">,</span></div>
+        <div><span class="t-white">{"  url: "}</span><span class="t-str">'https://mysite.com'</span><span class="t-white">,</span></div>
+        <div><span class="t-white">{"  schema: { organization: { name: "}</span><span class="t-str">'My Co'</span><span class="t-white">{" } },"}</span></div>
+        <div><span class="t-white">{"  widget: { size: "}</span><span class="t-str">'small'</span><span class="t-white">{" },"}</span></div>
+        <div><span class="t-white">{"});"}</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  const COMMANDS: Record<string, string> = {
+    install: 'npm install aeo.js',
+    audit: 'npx aeo.js audit',
+    generate: 'npx aeo.js generate',
+  };
+
+  function typeCommand(el: HTMLElement, text: string, cursor: HTMLElement, output: HTMLElement) {
+    el.textContent = '';
+    cursor.style.display = 'inline';
+    output.style.opacity = '0';
+    output.style.transform = 'translateY(6px)';
+    let i = 0;
+    const interval = setInterval(() => {
+      el.textContent += text[i];
+      i++;
+      if (i >= text.length) {
+        clearInterval(interval);
+        cursor.style.display = 'none';
+        setTimeout(() => {
+          output.style.opacity = '1';
+          output.style.transform = 'translateY(0)';
+        }, 200);
+      }
+    }, 45);
+    return interval;
+  }
+
+  let currentInterval: ReturnType<typeof setInterval> | null = null;
+
+  function activateTab(tab: string) {
+    const terminal = document.getElementById('hero-terminal');
+    if (!terminal) return;
+
+    // Clear any running animation
+    if (currentInterval) clearInterval(currentInterval);
+
+    // Switch tabs
+    terminal.querySelectorAll('.terminal-tab').forEach(t => t.classList.remove('active'));
+    terminal.querySelectorAll('.terminal-panel').forEach(p => p.classList.remove('active'));
+    terminal.querySelector(`[data-tab="${tab}"]`)?.classList.add('active');
+    const panel = document.getElementById(`panel-${tab}`);
+    if (panel) panel.classList.add('active');
+
+    // Type command if applicable
+    const cmd = COMMANDS[tab];
+    if (cmd) {
+      const cmdEl = document.getElementById(`cmd-${tab}`);
+      const cursor = panel?.querySelector('.t-cursor') as HTMLElement;
+      const output = document.getElementById(`out-${tab}`);
+      if (cmdEl && cursor && output) {
+        currentInterval = typeCommand(cmdEl, cmd, cursor, output);
+      }
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const terminal = document.getElementById('hero-terminal');
+    if (!terminal) return;
+
+    terminal.querySelectorAll('.terminal-tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        activateTab((tab as HTMLElement).dataset.tab!);
+      });
+    });
+
+    // Auto-start first tab
+    activateTab('install');
+  });
+  // Also handle Astro View Transitions
+  document.addEventListener('astro:page-load', () => {
+    const terminal = document.getElementById('hero-terminal');
+    if (terminal) activateTab('install');
+  });
+</script>
+
+<style>
+  .terminal {
+    max-width: 580px;
+    width: 100%;
+    margin: 2rem auto 0;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    background: rgba(255, 255, 255, 0.02);
+    overflow: hidden;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+    font-family: 'JetBrains Mono', monospace;
+  }
+
+  .terminal-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    background: rgba(255, 255, 255, 0.015);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
+  .terminal-dots {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+  }
+
+  .dot-red { background: #ff5f57; opacity: 0.8; }
+  .dot-yellow { background: #ffbd2e; opacity: 0.8; }
+  .dot-green { background: #28c840; opacity: 0.8; }
+
+  .terminal-tabs {
+    display: flex;
+    gap: 1px;
+    margin-left: 8px;
+  }
+
+  .terminal-tab {
+    padding: 4px 10px;
+    border: none;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.3);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10.5px;
+    font-weight: 500;
+    cursor: pointer;
+    border-radius: 5px;
+    transition: all 0.15s ease;
+    letter-spacing: 0.01em;
+  }
+
+  .terminal-tab:hover {
+    color: rgba(255, 255, 255, 0.55);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .terminal-tab.active {
+    color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .terminal-body {
+    padding: 18px 18px 22px;
+    min-height: 190px;
+    font-size: 12.5px;
+    line-height: 1.65;
+  }
+
+  .terminal-panel {
+    display: none;
+  }
+
+  .terminal-panel.active {
+    display: block;
+  }
+
+  .terminal-line {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    white-space: nowrap;
+  }
+
+  .t-prompt { color: #4ADE80; font-weight: 600; }
+  .t-cmd { color: #fff; }
+  .t-cursor { color: rgba(255,255,255,0.7); animation: blink 1s steps(1) infinite; }
+  .t-dim { color: rgba(255, 255, 255, 0.35); }
+  .t-white { color: #fff; }
+  .t-green { color: #4ADE80; }
+  .t-purple { color: #c084fc; }
+  .t-str { color: #86efac; }
+
+  .terminal-output {
+    margin-top: 8px;
+    opacity: 0;
+    transform: translateY(6px);
+    transition: opacity 0.4s ease, transform 0.4s ease;
+  }
+
+  .terminal-output-visible {
+    opacity: 1 !important;
+    transform: translateY(0) !important;
+  }
+
+  @keyframes blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+  }
+
+  @media (max-width: 640px) {
+    .terminal {
+      margin: 1.5rem 0 0;
+      border-radius: 10px;
+    }
+
+    .terminal-body {
+      padding: 14px;
+      font-size: 11px;
+      min-height: 170px;
+    }
+
+    .terminal-tab {
+      font-size: 9.5px;
+      padding: 3px 7px;
+    }
+  }
+
+  :global([data-theme="light"]) .terminal {
+    background: rgba(0, 0, 0, 0.03);
+    border-color: rgba(0, 0, 0, 0.08);
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.1);
+  }
+
+  :global([data-theme="light"]) .terminal-header {
+    background: rgba(0, 0, 0, 0.02);
+    border-bottom-color: rgba(0, 0, 0, 0.06);
+  }
+
+  :global([data-theme="light"]) .terminal-tab {
+    color: rgba(0, 0, 0, 0.35);
+  }
+
+  :global([data-theme="light"]) .terminal-tab:hover {
+    color: rgba(0, 0, 0, 0.6);
+    background: rgba(0, 0, 0, 0.04);
+  }
+
+  :global([data-theme="light"]) .terminal-tab.active {
+    color: rgba(0, 0, 0, 0.85);
+    background: rgba(0, 0, 0, 0.06);
+  }
+
+  :global([data-theme="light"]) .t-prompt { color: #16a34a; }
+  :global([data-theme="light"]) .t-cmd { color: #000; }
+  :global([data-theme="light"]) .t-white { color: #000; }
+  :global([data-theme="light"]) .t-dim { color: rgba(0, 0, 0, 0.4); }
+  :global([data-theme="light"]) .t-green { color: #16a34a; }
+  :global([data-theme="light"]) .t-purple { color: #9333ea; }
+  :global([data-theme="light"]) .t-str { color: #16a34a; }
+  :global([data-theme="light"]) .t-cursor { color: rgba(0,0,0,0.5); }
+</style>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -3,50 +3,18 @@ title: aeo.js
 description: Answer Engine Optimization for the modern web. Make your site discoverable by AI crawlers and LLMs.
 template: splash
 hero:
-  tagline: Make your site discoverable by ChatGPT, Claude, Perplexity, and every AI answer engine — automatically.
+  tagline: Make your site discoverable by ChatGPT, Claude, Perplexity, and every AI answer engine, automatically.
   actions:
     - text: Get Started
       link: /getting-started/introduction/
       icon: right-arrow
       variant: primary
-    - text: GitHub
-      link: https://github.com/multivmlabs/aeo.js
-      icon: external
-      variant: minimal
-    - text: npm
-      link: https://www.npmjs.com/package/aeo.js
-      icon: external
-      variant: minimal
 ---
 
-import { Card, CardGrid, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import StickyNav from '../../components/StickyNav.astro';
 
-## What is AEO?
-
-Answer Engine Optimization (AEO) is the practice of making your website discoverable and citable by AI-powered answer engines like ChatGPT, Claude, Perplexity, and SearchGPT.
-
-**aeo.js** auto-generates the files these engines look for and provides a drop-in widget that shows visitors how your site appears to AI.
-
-<CardGrid>
-  <Card title="llms.txt & llms-full.txt" icon="document">
-    LLM-readable summaries of your site, auto-generated from your pages.
-  </Card>
-  <Card title="robots.txt" icon="setting">
-    AI-crawler-aware robots directives with sensible defaults for all major AI bots.
-  </Card>
-  <Card title="Sitemap & AI Index" icon="list-format">
-    Standard sitemap.xml plus an ai-index.json optimized for RAG pipelines.
-  </Card>
-  <Card title="Human/AI Widget" icon="rocket">
-    Drop-in toggle showing the AI-readable version of any page.
-  </Card>
-  <Card title="6 Frameworks" icon="puzzle">
-    First-class support for Astro, Next.js, Vite, Nuxt, Angular, and Webpack.
-  </Card>
-  <Card title="CLI" icon="laptop">
-    Run standalone with npx aeo.js generate — no framework integration needed.
-  </Card>
-</CardGrid>
+<StickyNav />
 
 ## Quick Start
 
@@ -177,6 +145,39 @@ npm install aeo.js
   </TabItem>
 </Tabs>
 
+## What is AEO?
+
+Answer Engine Optimization (AEO) is the practice of making your website discoverable and citable by AI-powered answer engines like ChatGPT, Claude, Perplexity, and SearchGPT.
+
+**aeo.js** auto-generates the files these engines look for and provides a drop-in widget that shows visitors how your site appears to AI. First-class support for Astro, Next.js, Vite, Nuxt, Angular, and Webpack — or run standalone via CLI.
+
+## Why AEO matters
+
+<div class="why-aeo-grid">
+  <div class="why-card">
+    <div class="why-stat">58%</div>
+    <div class="why-label">of searches</div>
+    <div class="why-desc">end without a click — AI gives the answer directly</div>
+  </div>
+  <div class="why-card">
+    <div class="why-stat">40%</div>
+    <div class="why-label">of Gen Z</div>
+    <div class="why-desc">prefer AI assistants over traditional search engines</div>
+  </div>
+  <div class="why-card">
+    <div class="why-stat">97%</div>
+    <div class="why-label">of sites</div>
+    <div class="why-desc">have no llms.txt or structured data for AI crawlers</div>
+  </div>
+  <div class="why-card">
+    <div class="why-stat">1 min</div>
+    <div class="why-label">to set up</div>
+    <div class="why-desc">aeo.js generates robots.txt, llms.txt, schema &amp; more</div>
+  </div>
+</div>
+
+If your site isn't optimized for AI engines, you're invisible to a growing share of users who never open a search results page. AEO is the new SEO.
+
 ## Widget
 
 The Human/AI widget lets visitors toggle between the normal page and its AI-readable markdown version. Framework plugins inject it automatically — for Next.js or manual setups:
@@ -272,18 +273,17 @@ After building, your output directory contains:
 
 ```
 public/
-  robots.txt          # AI-crawler-aware directives
-  llms.txt            # Short LLM-readable summary
-  llms-full.txt       # Full content for LLMs
-  sitemap.xml         # Standard sitemap
-  docs.json           # Documentation manifest
-  ai-index.json       # AI-optimized content index
-  index.md            # Markdown for /
-  about.md            # Markdown for /about
-  …                   # One .md per page
+├── robots.txt          # AI-crawler directives
+├── llms.txt            # Short LLM-readable summary
+├── llms-full.txt       # Full content for LLMs
+├── sitemap.xml         # Standard sitemap
+├── docs.json           # Documentation manifest
+├── ai-index.json       # AI content index
+├── index.md            # Markdown for /
+└── about.md            # Markdown for /about
 ```
 
-## Check your site's AEO readiness
+## Checker
 
 <div class="aeo-checker-widget" style={{marginTop: '1rem', marginBottom: '0.5rem'}}>
   <form id="aeo-check-form" class="aeo-checker-input-wrap" action="https://check.aeojs.org" method="GET">

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -1,7 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=Figtree:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Figtree:wght@300;400;500;600;700;800;900&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&display=swap');
 
 /* ──────────────────────────────────────────────
-   Color palette — pure black glassmorphism
+   Color palette — dark only
    ────────────────────────────────────────────── */
 :root {
 	--sl-color-accent-low: rgba(255, 255, 255, 0.06);
@@ -29,7 +29,7 @@
 	--sl-content-width: 48rem;
 	--sl-nav-height: 4rem;
 
-	--sl-text-h1: clamp(2rem, 4vw, 2.5rem);
+	--sl-text-h1: clamp(1.5rem, 3vw, 2rem);
 	--sl-text-h2: clamp(1.4rem, 3vw, 1.8rem);
 	--sl-text-h3: 1.2rem;
 	--sl-text-body: 0.95rem;
@@ -38,52 +38,35 @@
 	--sl-line-height: 1.7;
 }
 
-[data-theme="light"] {
-	--sl-color-accent-low: rgba(0, 0, 0, 0.04);
-	--sl-color-accent: #000000;
-	--sl-color-accent-high: #000000;
-	--sl-color-white: #000000;
-	--sl-color-gray-1: #2a2a2a;
-	--sl-color-gray-2: #505050;
-	--sl-color-gray-3: #808080;
-	--sl-color-gray-4: #b0b0b0;
-	--sl-color-gray-5: #e8e8e8;
-	--sl-color-gray-6: #f5f5f5;
-	--sl-color-black: #ffffff;
-	--sl-color-bg-nav: rgba(255, 255, 255, 0.85);
-	--sl-color-bg-sidebar: rgba(255, 255, 255, 0.7);
-	--sl-color-hairline-shade: rgba(0, 0, 0, 0.08);
-	--sl-color-hairline-light: rgba(0, 0, 0, 0.05);
-	--sl-color-bg-inline-code: rgba(0, 0, 0, 0.06);
-	--sl-color-text: #333333;
-	--sl-color-text-accent: #000000;
-}
-
 /* ──────────────────────────────────────────────
    Global
    ────────────────────────────────────────────── */
 html {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	color-scheme: dark;
 }
 
 body {
 	background: #000 !important;
 }
 
-[data-theme="light"] body {
-	background: #ffffff !important;
+/* Force dark mode — hide theme toggle */
+starlight-theme-select {
+	display: none !important;
 }
 
 /* ──────────────────────────────────────────────
-   Header — glassmorphic nav bar
+   Header — glassmorphic nav bar, centered container
    ────────────────────────────────────────────── */
 header.header {
-	background: var(--sl-color-bg-nav) !important;
-	backdrop-filter: blur(20px) saturate(1.4);
-	-webkit-backdrop-filter: blur(20px) saturate(1.4);
-	border-bottom: 1px solid var(--sl-color-hairline-shade) !important;
+	background: rgba(0, 0, 0, 0.85) !important;
+	backdrop-filter: blur(16px);
+	-webkit-backdrop-filter: blur(16px);
+	border-bottom: 1px solid rgba(255, 255, 255, 0.05) !important;
 }
+
+/* Header container centering handled in Header.astro */
 
 /* ──────────────────────────────────────────────
    Sidebar — glassmorphic panel
@@ -102,17 +85,16 @@ nav.sidebar a[aria-current="true"] {
 	border-radius: 8px;
 }
 
-[data-theme="light"] nav.sidebar a[aria-current="page"],
-[data-theme="light"] nav.sidebar a[aria-current="true"] {
-	background: rgba(0, 0, 0, 0.06) !important;
-	color: #000 !important;
-}
-
 /* ──────────────────────────────────────────────
    Content typography
    ────────────────────────────────────────────── */
 .sl-markdown-content h1,
-.sl-markdown-content h2,
+.sl-markdown-content h2 {
+	font-family: 'Instrument Serif', Georgia, serif;
+	font-weight: 400;
+	letter-spacing: 0.01em;
+}
+
 .sl-markdown-content h3,
 .sl-markdown-content h4 {
 	font-weight: 700;
@@ -137,15 +119,18 @@ nav.sidebar a[aria-current="true"] {
 }
 
 .expressive-code .frame {
-	background: rgba(255, 255, 255, 0.03) !important;
-	border: 1px solid rgba(255, 255, 255, 0.08) !important;
-	border-radius: 12px !important;
-	backdrop-filter: blur(12px);
+	background: rgba(255, 255, 255, 0.02) !important;
+	border: 1px solid rgba(255, 255, 255, 0.06) !important;
+	border-radius: 10px !important;
 }
 
-[data-theme="light"] .expressive-code .frame {
-	background: rgba(0, 0, 0, 0.03) !important;
-	border: 1px solid rgba(0, 0, 0, 0.08) !important;
+/* Hide terminal header on bash code blocks (no title needed) */
+.expressive-code .frame.is-terminal .header:not(:has(.title:not(:empty))) {
+	display: none !important;
+}
+
+.expressive-code .frame.is-terminal .header {
+	display: none !important;
 }
 
 /* Inline code */
@@ -170,43 +155,65 @@ nav.sidebar a[aria-current="true"] {
 }
 
 .card:hover {
-	border-color: rgba(255, 255, 255, 0.16) !important;
-	background: rgba(255, 255, 255, 0.06) !important;
-}
-
-[data-theme="light"] .card {
-	background: rgba(0, 0, 0, 0.02) !important;
-	border: 1px solid rgba(0, 0, 0, 0.08) !important;
-}
-
-[data-theme="light"] .card:hover {
-	border-color: rgba(0, 0, 0, 0.14) !important;
-	background: rgba(0, 0, 0, 0.04) !important;
+	border-color: rgba(255, 255, 255, 0.12) !important;
 }
 
 .card .card-title {
-	font-weight: 600;
+	font-family: 'Instrument Serif', Georgia, serif;
+	font-weight: 400;
+	letter-spacing: 0.01em;
+	font-size: 1.15rem;
 }
 
 /* ──────────────────────────────────────────────
-   Tabs — glassmorphic
+   Tabs — matching hero terminal style
    ────────────────────────────────────────────── */
+starlight-tabs {
+	border-radius: 12px !important;
+	border: 1px solid rgba(255, 255, 255, 0.06) !important;
+	background: rgba(255, 255, 255, 0.02) !important;
+	overflow: hidden;
+}
+
 starlight-tabs [role="tablist"] {
-	border-bottom: 1px solid rgba(255, 255, 255, 0.08) !important;
+	background: rgba(255, 255, 255, 0.015) !important;
+	border-bottom: none !important;
+	border: none !important;
+	box-shadow: none !important;
+	padding: 10px 14px !important;
+	gap: 2px;
+}
+
+starlight-tabs .tablist-wrapper {
+	border-bottom: none !important;
 }
 
 starlight-tabs [role="tab"] {
+	font-family: 'JetBrains Mono', monospace !important;
 	font-weight: 500 !important;
+	font-size: 13px !important;
+	padding: 6px 14px !important;
+	border-radius: 6px !important;
+	border: none !important;
+	color: rgba(255, 255, 255, 0.3) !important;
+	letter-spacing: 0.01em;
+	transition: all 0.15s ease;
+}
+
+starlight-tabs [role="tab"]:hover {
+	color: rgba(255, 255, 255, 0.55) !important;
+	background: rgba(255, 255, 255, 0.03) !important;
 }
 
 starlight-tabs [role="tab"][aria-selected="true"] {
-	border-color: #fff !important;
-	color: #fff !important;
+	color: rgba(255, 255, 255, 0.85) !important;
+	background: rgba(255, 255, 255, 0.06) !important;
+	border: none !important;
+	box-shadow: none !important;
 }
 
-[data-theme="light"] starlight-tabs [role="tab"][aria-selected="true"] {
-	border-color: #000 !important;
-	color: #000 !important;
+starlight-tabs [role="tabpanel"] {
+	padding: 18px !important;
 }
 
 /* ──────────────────────────────────────────────
@@ -217,11 +224,6 @@ starlight-tabs [role="tab"][aria-selected="true"] {
 	border: 1px solid rgba(255, 255, 255, 0.1) !important;
 	border-radius: 12px !important;
 	backdrop-filter: blur(8px);
-}
-
-[data-theme="light"] .starlight-aside {
-	background: rgba(0, 0, 0, 0.03) !important;
-	border: 1px solid rgba(0, 0, 0, 0.08) !important;
 }
 
 /* ──────────────────────────────────────────────
@@ -249,19 +251,6 @@ starlight-tabs [role="tab"][aria-selected="true"] {
 	padding: 0.75rem 1rem !important;
 }
 
-[data-theme="light"] .sl-markdown-content table {
-	border-color: rgba(0, 0, 0, 0.08);
-}
-
-[data-theme="light"] .sl-markdown-content th {
-	background: rgba(0, 0, 0, 0.03) !important;
-}
-
-[data-theme="light"] .sl-markdown-content td,
-[data-theme="light"] .sl-markdown-content th {
-	border-color: rgba(0, 0, 0, 0.06) !important;
-}
-
 /* ──────────────────────────────────────────────
    Links
    ────────────────────────────────────────────── */
@@ -276,15 +265,6 @@ starlight-tabs [role="tab"][aria-selected="true"] {
 	text-decoration-color: rgba(255, 255, 255, 0.8) !important;
 }
 
-[data-theme="light"] .sl-markdown-content a:not(.card):not([class*="action"]) {
-	color: #000 !important;
-	text-decoration-color: rgba(0, 0, 0, 0.3) !important;
-}
-
-[data-theme="light"] .sl-markdown-content a:not(.card):not([class*="action"]):hover {
-	text-decoration-color: rgba(0, 0, 0, 0.8) !important;
-}
-
 /* ──────────────────────────────────────────────
    Hero overrides
    ────────────────────────────────────────────── */
@@ -292,60 +272,111 @@ starlight-tabs [role="tab"][aria-selected="true"] {
 	background: transparent !important;
 }
 
-.hero {
-	padding-block: 4rem !important;
+/* Grid background on hero area */
+[data-has-hero] .page::before {
+	content: '';
+	position: absolute;
+	inset: 0;
+	height: 100vh;
+	background-image:
+		linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+	background-size: 60px 60px;
+	mask-image: linear-gradient(to bottom, rgba(0,0,0,0.6) 0%, transparent 80%);
+	-webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,0.6) 0%, transparent 80%);
+	pointer-events: none;
+	z-index: 0;
 }
 
+/* Hide the hero h1 title — already in header */
+.hero h1 {
+	display: none !important;
+}
+
+/* Promote tagline to hero title with Instrument Serif */
 .hero .tagline {
-	font-size: clamp(1.1rem, 2.5vw, 1.4rem) !important;
-	color: var(--sl-color-gray-2) !important;
-	line-height: 1.6 !important;
-	max-width: 32rem;
+	font-family: 'Instrument Serif', Georgia, serif !important;
+	font-size: clamp(1.8rem, 4vw, 2.8rem) !important;
+	font-weight: 400 !important;
+	letter-spacing: 0.01em !important;
+	color: var(--sl-color-white) !important;
+	line-height: 1.25 !important;
+	max-width: 26rem;
+	min-height: 3.5em;
 }
 
+/* Hero layout */
+.hero {
+	padding-block: 3rem 2rem !important;
+}
+
+[data-has-hero] .content-panel {
+	max-width: 72rem !important;
+	margin-inline: auto !important;
+	width: 100% !important;
+}
+
+.content-panel {
+	max-width: 72rem;
+	margin-inline: auto;
+}
+
+/* Center entire page layout to match header's 72rem container */
+.page {
+	max-width: 72rem;
+	margin-inline: auto;
+}
+
+/* Fixed sidebar must respect the centered page */
+@media (min-width: 50rem) {
+	.sidebar-pane {
+		left: auto !important;
+		inset-inline-start: max(0px, calc((100vw - 72rem) / 2)) !important;
+	}
+
+	header.header {
+		left: 0 !important;
+		right: 0 !important;
+	}
+}
+
+/* Content area in docs fills available space */
+.main-pane {
+	padding-inline: 1.5rem;
+}
+
+/* CTA button — big primary */
 .hero .action {
-	border-radius: 10px !important;
-	font-weight: 600 !important;
-	letter-spacing: -0.01em;
+	text-decoration: none !important;
 	transition: all 0.2s ease !important;
 }
 
 .hero .action.primary {
-	background: #fff !important;
-	color: #000 !important;
-	border: 1px solid rgba(255, 255, 255, 0.2) !important;
-	box-shadow: 0 0 20px rgba(255, 255, 255, 0.1), 0 2px 8px rgba(255, 255, 255, 0.1);
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.65rem 1.25rem !important;
+	border-radius: 10px !important;
+	font-size: 0.9rem !important;
+	font-weight: 500 !important;
+	letter-spacing: -0.01em;
+	background: linear-gradient(135deg, #2a2a2a 0%, #1a1a1a 100%) !important;
+	color: #fff !important;
+	border: 1px solid rgba(255, 255, 255, 0.1) !important;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .hero .action.primary:hover {
-	box-shadow: 0 0 30px rgba(255, 255, 255, 0.15), 0 4px 16px rgba(255, 255, 255, 0.15);
+	background: linear-gradient(135deg, #383838 0%, #252525 100%) !important;
+	border-color: rgba(255, 255, 255, 0.18) !important;
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.08);
 	transform: translateY(-1px);
 }
 
-.hero .action.minimal {
-	background: rgba(255, 255, 255, 0.06) !important;
-	border: 1px solid rgba(255, 255, 255, 0.1) !important;
-	color: #d4d4d4 !important;
-	backdrop-filter: blur(8px);
-}
-
-.hero .action.minimal:hover {
-	background: rgba(255, 255, 255, 0.1) !important;
-	border-color: rgba(255, 255, 255, 0.18) !important;
-	color: #fff !important;
-}
-
-[data-theme="light"] .hero .action.primary {
-	background: #000 !important;
-	color: #fff !important;
-	border-color: #000 !important;
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-}
-
-[data-theme="light"] .hero .action.minimal {
-	background: rgba(0, 0, 0, 0.04) !important;
-	border: 1px solid rgba(0, 0, 0, 0.1) !important;
-	color: #555 !important;
+.hero .action.primary svg {
+	width: 16px;
+	height: 16px;
+	flex-shrink: 0;
 }
 
 /* ──────────────────────────────────────────────
@@ -362,11 +393,6 @@ starlight-tabs [role="tab"][aria-selected="true"] {
 .pagination-links a:hover {
 	background: rgba(255, 255, 255, 0.08) !important;
 	border-color: rgba(255, 255, 255, 0.16) !important;
-}
-
-[data-theme="light"] .pagination-links a {
-	background: rgba(0, 0, 0, 0.02) !important;
-	border: 1px solid rgba(0, 0, 0, 0.08) !important;
 }
 
 /* ──────────────────────────────────────────────
@@ -455,22 +481,22 @@ dialog {
 	gap: 0.5rem;
 	height: 3.25rem;
 	padding: 0 1.5rem;
-	border-radius: 10px;
-	font-size: 0.95rem;
-	font-weight: 600;
+	border-radius: 8px;
+	font-size: 0.9rem;
+	font-weight: 500;
 	font-family: 'Figtree', sans-serif;
-	color: #000;
-	background: linear-gradient(135deg, #fff 0%, #e0e0e0 100%);
-	border: none;
+	color: #fff;
+	background: linear-gradient(135deg, #2a2a2a 0%, #1a1a1a 100%);
+	border: 1px solid rgba(255, 255, 255, 0.1);
 	cursor: pointer;
 	white-space: nowrap;
-	transition: all 0.2s ease;
-	box-shadow: 0 2px 8px rgba(255, 255, 255, 0.12);
+	transition: all 0.15s ease;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .aeo-checker-btn:hover {
-	box-shadow: 0 4px 16px rgba(255, 255, 255, 0.18);
-	transform: translateY(-1px);
+	background: linear-gradient(135deg, #333 0%, #222 100%);
+	border-color: rgba(255, 255, 255, 0.18);
 }
 
 .aeo-checker-btn svg {
@@ -478,26 +504,74 @@ dialog {
 	height: 16px;
 }
 
-[data-theme="light"] .aeo-checker-input-wrap {
-	background: rgba(0, 0, 0, 0.04);
-	border-color: rgba(0, 0, 0, 0.12);
-	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+/* ──────────────────────────────────────────────
+   Why AEO grid
+   ────────────────────────────────────────────── */
+.why-aeo-grid {
+	display: flex !important;
+	gap: 1rem !important;
+	margin: 1.5rem 0 !important;
 }
 
-[data-theme="light"] .aeo-checker-input-wrap:focus-within {
-	border-color: rgba(0, 0, 0, 0.2);
+.why-aeo-grid > .why-card {
+	flex: 1 1 0% !important;
+	min-width: 0 !important;
+	height: 180px !important;
+	margin: 0 !important;
+	padding: 1.25rem !important;
+	border-radius: 16px !important;
+	background: rgba(255, 255, 255, 0.04) !important;
+	border: 1px solid rgba(255, 255, 255, 0.08) !important;
+	backdrop-filter: blur(12px);
+	-webkit-backdrop-filter: blur(12px);
+	transition: border-color 0.2s ease, background 0.2s ease;
+	display: flex !important;
+	flex-direction: column !important;
+	justify-content: center !important;
+	box-sizing: border-box !important;
 }
 
-[data-theme="light"] .aeo-checker-input {
-	color: #000;
+.why-aeo-grid > .why-card:hover {
+	border-color: rgba(255, 255, 255, 0.12) !important;
 }
 
-[data-theme="light"] .aeo-checker-input::placeholder {
-	color: rgba(0, 0, 0, 0.35);
+@media (max-width: 50rem) {
+	.why-aeo-grid {
+		flex-wrap: wrap !important;
+	}
+	.why-aeo-grid > .why-card {
+		flex: 1 1 calc(50% - 0.5rem) !important;
+		height: 160px !important;
+	}
 }
 
-[data-theme="light"] .aeo-checker-btn {
-	background: linear-gradient(135deg, #111 0%, #333 100%);
+@media (max-width: 30rem) {
+	.why-aeo-grid > .why-card {
+		flex: 1 1 100% !important;
+	}
+}
+
+.why-stat {
+	font-family: 'Instrument Serif', Georgia, serif;
+	font-size: 2rem;
+	font-weight: 400;
+	letter-spacing: 0.01em;
 	color: #fff;
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	line-height: 1;
+}
+
+.why-label {
+	font-size: 0.75rem;
+	font-weight: 500;
+	color: rgba(255, 255, 255, 0.5);
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	margin-top: 0.25rem;
+}
+
+.why-desc {
+	font-size: 0.8rem;
+	color: rgba(255, 255, 255, 0.35);
+	line-height: 1.5;
+	margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Website Redesign

### Changes
- **Hero**: Side-by-side layout with animated Terminal component + Instrument Serif tagline with typing animation
- **Dark-only mode**: Removed all light theme CSS, hidden theme toggle
- **Terminal**: Tabbed demo (Install/Audit/Generate/Config) with typing animation
- **StickyNav**: Glassmorphic floating panel with section anchors
- **Tabs**: Styled to match terminal tabs (JetBrains Mono, no border-bottom)
- **CTA**: Single 'Get Started' button with dark grey gradient and arrow
- **Why AEO matters**: Stat cards section (58% searches, 40% Gen Z, 97% sites, 1 min setup)
- **Header**: Nav links + npm downloads/GitHub stars badges + centered search
- **Layout**: 72rem centered container for header, sidebar, and content
- **Hero background**: Subtle grid pattern with fade mask
- **Footer**: Minimal custom footer