### PR TITLE
ci: auto-publish to npm on GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically publishes to npm when a new GitHub release is created.

## How it works
1. Bump version in `package.json`
2. Push to main
3. Create a GitHub release (`gh release create v0.x.x`)
4. CI runs `npm publish --provenance` automatically

## Requirements
- `NPM_TOKEN` secret must be set in repo settings (✅ done)