### PR TITLE
fix: guard virtual widget module when widget is disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aeo.js",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Answer Engine Optimization for the modern web. Make your site discoverable by AI crawlers and LLMs.",
   "bin": {
     "aeo.js": "./dist/cli.mjs",

--- a/src/plugins/vite.ts
+++ b/src/plugins/vite.ts
@@ -203,6 +203,9 @@ export function aeoVitePlugin(options: AeoConfig = {}): any {
 
     load(id: string) {
       if (id === '\0virtual:aeo-widget') {
+        if (!resolvedConfig.widget.enabled) {
+          return '// aeo.js widget disabled';
+        }
         const widgetConfig = {
           title: resolvedConfig.title,
           description: resolvedConfig.description,


### PR DESCRIPTION
When `widget.enabled` is `false`, the `virtual:aeo-widget` module now returns a no-op comment instead of initializing `AeoWidget`. This prevents the widget from rendering if the module is resolved via cache or HMR.

Bumps version to `0.0.10`.