### PR TITLE
fix: show 'aeo.js' in header, keep full title in page <title> tag

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig({
 			},
 		}),
 		starlight({
-			title: 'aeo.js — Answer Engine Optimization for the Modern Web',
+			title: 'aeo.js',
 			description: 'Make your website discoverable by ChatGPT, Claude, Perplexity & AI search engines. Auto-generates llms.txt, robots.txt, sitemap, JSON-LD structured data & more. Works with Next.js, Astro, Vite, Nuxt & Angular.',
 			social: [],
 			components: {

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -2,6 +2,9 @@
 title: aeo.js
 description: Answer Engine Optimization for the modern web. Make your site discoverable by AI crawlers and LLMs.
 template: splash
+head:
+  - tag: title
+    content: 'aeo.js — Answer Engine Optimization for the Modern Web'
 hero:
   tagline: Make your site discoverable by ChatGPT, Claude, Perplexity, and every AI answer engine, automatically.
   actions:


### PR DESCRIPTION
- Starlight site title changed to just `aeo.js` so the header brand shows the short name
- Homepage `<title>` tag overridden via frontmatter head to keep the full **aeo.js — Answer Engine Optimization for the Modern Web**
- Subpages continue to show e.g. `Installation | aeo.js`