### PR TITLE
fix: Next.js sitemap generation and multiple bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aeo.js",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Answer Engine Optimization for the modern web. Make your site discoverable by AI crawlers and LLMs.",
   "bin": {
     "aeo.js": "./dist/cli.mjs",

--- a/src/core/ai-index.ts
+++ b/src/core/ai-index.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from 'fs';
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
 import { join, relative, extname } from 'path';
 import { createHash } from 'crypto';
 import type { ResolvedAeoConfig, AIIndexEntry } from '../types';
@@ -154,8 +154,18 @@ export function generateAIIndex(config: ResolvedAeoConfig): string {
   }
 
   // Add markdown content files
-  entries.push(...collectAIIndexEntries(config.contentDir, config));
+  if (existsSync(config.contentDir)) {
+    entries.push(...collectAIIndexEntries(config.contentDir, config));
+  }
   
+  // Deduplicate entries by ID
+  const seenIds = new Set<string>();
+  const uniqueEntries = entries.filter(e => {
+    if (seenIds.has(e.id)) return false;
+    seenIds.add(e.id);
+    return true;
+  });
+
   const index = {
     version: '1.0',
     generated: new Date().toISOString(),
@@ -164,9 +174,9 @@ export function generateAIIndex(config: ResolvedAeoConfig): string {
       description: config.description,
       url: config.url,
     },
-    entries: entries.sort((a, b) => a.id.localeCompare(b.id)),
+    entries: uniqueEntries.sort((a, b) => a.id.localeCompare(b.id)),
     metadata: {
-      totalEntries: entries.length,
+      totalEntries: uniqueEntries.length,
       generator: 'aeo.js',
       generatorUrl: 'https://aeojs.org',
       embedding: {

--- a/src/core/detect.test.ts
+++ b/src/core/detect.test.ts
@@ -14,7 +14,7 @@ describe('detectFramework', () => {
     expect(result).toEqual({
       framework: 'next',
       contentDir: 'app',
-      outDir: 'out',
+      outDir: 'public',
     });
   });
 
@@ -133,7 +133,7 @@ describe('detectFramework', () => {
     expect(result).toEqual({
       framework: 'next',
       contentDir: 'app',
-      outDir: 'out',
+      outDir: 'public',
     });
   });
 });

--- a/src/core/detect.ts
+++ b/src/core/detect.ts
@@ -12,7 +12,7 @@ export function detectFramework(projectRoot: string = process.cwd()): FrameworkI
     return {
       framework: 'next',
       contentDir: 'app',
-      outDir: 'out',
+      outDir: 'public',
     };
   }
   

--- a/src/core/generate-wrapper.ts
+++ b/src/core/generate-wrapper.ts
@@ -48,8 +48,8 @@ export async function generateAEOFiles(
       const content = genRobots(config);
       writeFileSync(join(outDir, 'robots.txt'), content, 'utf-8');
       files.push('robots.txt');
-    } catch (e: any) {
-      errors.push(`robots.txt: ${e.message}`);
+    } catch (e: unknown) {
+      errors.push(`robots.txt: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -58,8 +58,8 @@ export async function generateAEOFiles(
       const content = genLlms(config);
       writeFileSync(join(outDir, 'llms.txt'), content, 'utf-8');
       files.push('llms.txt');
-    } catch (e: any) {
-      errors.push(`llms.txt: ${e.message}`);
+    } catch (e: unknown) {
+      errors.push(`llms.txt: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -68,8 +68,8 @@ export async function generateAEOFiles(
       const content = genLlmsFull(config);
       writeFileSync(join(outDir, 'llms-full.txt'), content, 'utf-8');
       files.push('llms-full.txt');
-    } catch (e: any) {
-      errors.push(`llms-full.txt: ${e.message}`);
+    } catch (e: unknown) {
+      errors.push(`llms-full.txt: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -80,8 +80,8 @@ export async function generateAEOFiles(
       for (const f of generated) {
         files.push(f.destination);
       }
-    } catch (e: any) {
-      errors.push(`page-markdown: ${e.message}`);
+    } catch (e: unknown) {
+      errors.push(`page-markdown: ${e instanceof Error ? e.message : String(e)}`);
     }
 
     // Then copy handwritten .md from contentDir (these take priority, overwriting generated ones)
@@ -90,8 +90,8 @@ export async function generateAEOFiles(
       for (const f of copied) {
         files.push(f.destination);
       }
-    } catch (e: any) {
-      errors.push(`raw-markdown: ${e.message}`);
+    } catch (e: unknown) {
+      errors.push(`raw-markdown: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -100,8 +100,8 @@ export async function generateAEOFiles(
       const content = genManifest(config);
       writeFileSync(join(outDir, 'docs.json'), content, 'utf-8');
       files.push('docs.json');
-    } catch (e: any) {
-      errors.push(`docs.json: ${e.message}`);
+    } catch (e: unknown) {
+      errors.push(`docs.json: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -110,8 +110,8 @@ export async function generateAEOFiles(
       const content = genSitemap(config);
       writeFileSync(join(outDir, 'sitemap.xml'), content, 'utf-8');
       files.push('sitemap.xml');
-    } catch (e: any) {
-      errors.push(`sitemap.xml: ${e.message}`);
+    } catch (e: unknown) {
+      errors.push(`sitemap.xml: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -120,8 +120,8 @@ export async function generateAEOFiles(
       const content = genAIIndex(config);
       writeFileSync(join(outDir, 'ai-index.json'), content, 'utf-8');
       files.push('ai-index.json');
-    } catch (e: any) {
-      errors.push(`ai-index.json: ${e.message}`);
+    } catch (e: unknown) {
+      errors.push(`ai-index.json: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -130,8 +130,8 @@ export async function generateAEOFiles(
       const content = genSchema(config);
       writeFileSync(join(outDir, 'schema.json'), content, 'utf-8');
       files.push('schema.json');
-    } catch (e: any) {
-      errors.push(`schema.json: ${e.message}`);
+    } catch (e: unknown) {
+      errors.push(`schema.json: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 

--- a/src/core/llms-full.ts
+++ b/src/core/llms-full.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from 'fs';
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
 import { join, relative, extname } from 'path';
 import type { ResolvedAeoConfig } from '../types';
 import { parseFrontmatter, bumpHeadings } from './utils';
@@ -103,7 +103,7 @@ export function generateLlmsFullTxt(config: ResolvedAeoConfig): string {
   }
 
   // Include markdown content files
-  const sections = collectAndConcatenateMarkdown(config.contentDir);
+  const sections = existsSync(config.contentDir) ? collectAndConcatenateMarkdown(config.contentDir) : [];
 
   if (sections.length > 0) {
     lines.push(...sections);

--- a/src/core/llms-txt.ts
+++ b/src/core/llms-txt.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from 'fs';
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
 import { join, relative, extname } from 'path';
 import type { ResolvedAeoConfig, MarkdownFile } from '../types';
 import { parseFrontmatter, extractTitle } from './utils';
@@ -71,7 +71,7 @@ export function generateLlmsTxt(config: ResolvedAeoConfig): string {
   }
 
   // List markdown content files
-  const markdownFiles = collectMarkdownFiles(config.contentDir);
+  const markdownFiles = existsSync(config.contentDir) ? collectMarkdownFiles(config.contentDir) : [];
 
   if (markdownFiles.length > 0) {
     lines.push('## Documentation');

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from 'fs';
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
 import { join, relative, extname } from 'path';
 import type { ResolvedAeoConfig, ManifestEntry } from '../types';
 import { parseFrontmatter, extractTitle } from './utils';
@@ -51,7 +51,9 @@ export function generateManifest(config: ResolvedAeoConfig): string {
   }
 
   // Add markdown content files
-  entries.push(...collectManifestEntries(config.contentDir, config));
+  if (existsSync(config.contentDir)) {
+    entries.push(...collectManifestEntries(config.contentDir, config));
+  }
   
   const manifest = {
     version: '1.0',

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -175,10 +175,11 @@ function detectFaqPatterns(content: string): { question: string; answer: string 
   const items: { question: string; answer: string }[] = [];
 
   // Pattern: ## Question? \n\n Answer text
+  // Only match headings that look like genuine questions (start with question words or end cleanly with ?)
   const lines = content.split('\n');
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i].trim();
-    const headingMatch = line.match(/^#{1,6}\s+(.+\?)\s*$/);
+    const headingMatch = line.match(/^#{1,6}\s+((?:What|How|Why|When|Where|Who|Which|Is|Are|Can|Do|Does|Should|Will|Was|Were|Did|Has|Have|Could|Would)\b.+\?)\s*$/i);
     if (headingMatch) {
       // Collect answer: all non-empty, non-heading lines following
       const answerLines: string[] = [];

--- a/src/core/sitemap.test.ts
+++ b/src/core/sitemap.test.ts
@@ -16,6 +16,7 @@ describe('generateSitemap', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-01-15T10:30:00Z'));
     
+    mockFs.existsSync.mockReturnValue(true);
     mockPath.join.mockImplementation((...args: string[]) => args.join('/'));
     mockPath.relative.mockImplementation((from: string, to: string) => 
       to.replace(from + '/', '')

--- a/src/core/sitemap.ts
+++ b/src/core/sitemap.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync } from 'fs';
+import { readdirSync, statSync, existsSync } from 'fs';
 import { join, relative, extname } from 'path';
 import type { ResolvedAeoConfig } from '../types';
 
@@ -48,7 +48,7 @@ export function generateSitemap(config: ResolvedAeoConfig): string {
   }
 
   // Add markdown/html files from content dir
-  if (config.contentDir) {
+  if (config.contentDir && existsSync(config.contentDir)) {
     urls.push(...collectUrls(config.contentDir, config));
   }
 

--- a/src/plugins/astro.ts
+++ b/src/plugins/astro.ts
@@ -145,10 +145,11 @@ function injectHeadTags(pages: ScannedPage[], config: ResolvedAeoConfig): number
 
     // Link alternate tags for AEO files — only if not already present
     if (!/rel=["']alternate["'][^>]*llms\.txt/i.test(html)) {
-      tags.push(`<link rel="alternate" type="text/plain" href="/llms.txt" title="LLM Summary" />`);
-      tags.push(`<link rel="alternate" type="text/plain" href="/llms-full.txt" title="Full Content for LLMs" />`);
-      tags.push(`<link rel="alternate" type="application/json" href="/docs.json" title="Documentation Manifest" />`);
-      tags.push(`<link rel="alternate" type="application/json" href="/ai-index.json" title="AI-Optimized Index" />`);
+      const base = config.url ? new URL(config.url).pathname.replace(/\/$/, '') : '';
+      tags.push(`<link rel="alternate" type="text/plain" href="${base}/llms.txt" title="LLM Summary" />`);
+      tags.push(`<link rel="alternate" type="text/plain" href="${base}/llms-full.txt" title="Full Content for LLMs" />`);
+      tags.push(`<link rel="alternate" type="application/json" href="${base}/docs.json" title="Documentation Manifest" />`);
+      tags.push(`<link rel="alternate" type="application/json" href="${base}/ai-index.json" title="AI-Optimized Index" />`);
     }
 
     if (tags.length === 0) continue;

--- a/src/plugins/next.ts
+++ b/src/plugins/next.ts
@@ -36,14 +36,20 @@ function scanAppRouter(dir: string, base: string, pages: PageEntry[]): void {
     for (const entry of entries) {
       const fullPath = join(dir, entry);
       const stat = statSync(fullPath);
-      if (stat.isDirectory() && !entry.startsWith('.') && !entry.startsWith('_') && !entry.startsWith('(') && entry !== 'api') {
+      if (stat.isDirectory() && !entry.startsWith('.') && !entry.startsWith('_') && entry !== 'api') {
+        // Enter route groups (parenthesized dirs) but also regular dirs and dynamic segments
         scanAppRouter(fullPath, base, pages);
       } else if (entry.match(/^page\.(tsx?|jsx?|mdx?)$/)) {
+        // Build pathname: strip route group segments like (marketing)
         const relative = dir.slice(base.length);
-        const pathname = relative || '/';
-        const name = pathname.split('/').filter(Boolean).pop();
+        const pathname = relative
+          .split('/')
+          .filter(seg => seg && !seg.startsWith('('))
+          .join('/');
+        const cleanPathname = '/' + pathname;
+        const name = cleanPathname.split('/').filter(Boolean).pop();
         pages.push({
-          pathname,
+          pathname: cleanPathname === '/' ? '/' : cleanPathname,
           title: name ? name.charAt(0).toUpperCase() + name.slice(1) : undefined,
         });
       }
@@ -87,7 +93,9 @@ export function withAeo(nextConfig: NextAeoConfig = {}): Record<string, any> {
 
       if (!options.isServer && !options.dev) {
         const projectRoot = process.cwd();
-        const discoveredPages = scanNextPages(projectRoot);
+        const discoveredPages = scanNextPages(projectRoot)
+          // Filter out dynamic route segments — they're templates, not real URLs
+          .filter(p => !p.pathname.includes('['));
 
         // Default root page title/description to config values
         for (const page of discoveredPages) {
@@ -232,14 +240,43 @@ function scanNextBuildOutput(projectRoot: string): PageEntry[] {
  */
 export async function postBuild(config: AeoConfig = {}): Promise<void> {
   const projectRoot = process.cwd();
-  const discoveredPages = scanNextBuildOutput(projectRoot);
 
-  if (discoveredPages.length > 0) {
-    console.log(`[aeo.js] Discovered ${discoveredPages.length} pages from Next.js build output`);
+  // Discover pages from both source files AND build output
+  const sourcePages = scanNextPages(projectRoot);
+  const buildPages = scanNextBuildOutput(projectRoot);
+
+  if (sourcePages.length > 0) {
+    console.log(`[aeo.js] Discovered ${sourcePages.length} routes from source files`);
+  }
+  if (buildPages.length > 0) {
+    console.log(`[aeo.js] Discovered ${buildPages.length} pages from Next.js build output`);
+  }
+
+  // Merge: build output pages have richer content (title, description, content),
+  // so prefer them when available, but keep source-only routes too
+  const buildMap = new Map(buildPages.map(p => [p.pathname, p]));
+  const mergedPages: PageEntry[] = [];
+  const seen = new Set<string>();
+
+  // Add all build output pages first (they have content)
+  for (const page of buildPages) {
+    // Skip dynamic route patterns from build output
+    if (page.pathname.includes('[') || page.pathname.includes('%5B')) continue;
+    mergedPages.push(page);
+    seen.add(page.pathname);
+  }
+
+  // Add source-discovered routes not in build output (SSR/dynamic pages)
+  for (const page of sourcePages) {
+    // Skip dynamic route segments — they're templates, not real URLs
+    if (page.pathname.includes('[')) continue;
+    if (seen.has(page.pathname)) continue;
+    mergedPages.push(page);
+    seen.add(page.pathname);
   }
 
   // Default root page title/description from config
-  for (const page of discoveredPages) {
+  for (const page of mergedPages) {
     if (page.pathname === '/' && !page.title && config.title) {
       page.title = config.title;
     }
@@ -256,7 +293,7 @@ export async function postBuild(config: AeoConfig = {}): Promise<void> {
     ...config,
     outDir: config.outDir || join(projectRoot, 'public'),
     contentDir,
-    pages: [...(config.pages || []), ...discoveredPages],
+    pages: [...(config.pages || []), ...mergedPages],
   });
 
   const result = await generateAEOFiles(resolvedConfig);

--- a/src/plugins/nuxt.ts
+++ b/src/plugins/nuxt.ts
@@ -176,7 +176,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Dev: watch content directory for changes
     if (nuxt.options.dev) {
       nuxt.hook('builder:watch', async (_event: string, path: string) => {
-        if (path.includes(resolvedConfig.contentDir) && (path.endsWith('.md') || path.endsWith('.yml') || path.endsWith('.yaml'))) {
+        if ((path.startsWith(resolvedConfig.contentDir) || path.startsWith('/' + resolvedConfig.contentDir)) && (path.endsWith('.md') || path.endsWith('.yml') || path.endsWith('.yaml'))) {
           console.log('[aeo.js] Content changed, regenerating AEO files...');
 
           try {


### PR DESCRIPTION
## Summary
- **Next.js sitemap fix**: `postBuild()` now merges source-discovered routes with build output pages, so SSR/dynamic routes appear in sitemap and llms.txt. Previously only statically pre-rendered pages were included.
- **Route group support**: `scanAppRouter` now enters Next.js route groups (dirs starting with `(`) and strips them from pathnames
- **Dynamic route filtering**: Segments like `[id]`, `[...slug]` no longer appear as literal URLs in generated files
- **existsSync guards**: All generators now check `contentDir` exists before reading — prevents crashes when directory is missing
- **Next.js outDir**: Changed from `'out'` to `'public'` in framework detection (out is only for `next export`)
- **FAQ detection**: Tightened to only match headings starting with question words (What, How, Why, etc.)
- **AI-index dedup**: Entries deduplicated by ID before writing
- **Astro base path**: Link alternate tags respect site base path
- **Nuxt watcher**: Uses `startsWith` instead of `includes` for path matching
- **Error handling**: `catch (e: any)` → `catch (e: unknown)` with proper instanceof checks

## Test plan
- [x] All 142 tests passing
- [x] TypeScript type-check clean
- [ ] Test with a Next.js app that has route groups, dynamic routes, and SSR pages
- [ ] Test with a Next.js app where contentDir doesn't exist
- [ ] Verify Astro sites with base path get correct alternate links

🤖 Generated with [Claude Code](https://claude.com/claude-code)