### PR TITLE
fix(widget): break mutual recursion between closeOverlay and switchToHuman

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aeo.js",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Answer Engine Optimization for the modern web. Make your site discoverable by AI crawlers and LLMs.",
   "bin": {
     "aeo.js": "./dist/cli.mjs",

--- a/src/widget/core.ts
+++ b/src/widget/core.ts
@@ -495,7 +495,8 @@ export class AeoWidget {
       this.overlayElement.remove();
       this.overlayElement = undefined;
     }
-    this.switchToHuman();
+    this.isAIMode = false;
+    this.updateToggleState();
   }
 
   private async copyToClipboard(text: string): Promise<void> {


### PR DESCRIPTION
## Problem

`closeOverlay()` calls `this.switchToHuman()`, which in turn calls `this.closeOverlay()`, creating an infinite mutual recursion that results in a `"too much recursion"` runtime error whenever the overlay is closed.

## Solution

In `closeOverlay()`, instead of delegating to `switchToHuman()`, the state reset is inlined directly.

This breaks the cycle while preserving the intended behavior. `switchToHuman()` still calls `closeOverlay()` as it's the entry point from the toggle button — the fix is one-directional.

## Additional changes

Added `.prettierrc` with `singleQuote: true` preference.