### PR TITLE
fix: filter sitemap pathnames from generated sitemap.xml

### DIFF
--- a/src/core/sitemap.test.ts
+++ b/src/core/sitemap.test.ts
@@ -254,21 +254,6 @@ describe('generateSitemap', () => {
     expect(sitemap).not.toContain('/sitemap-index');
   });
 
-  it('still extracts a pathname when a contentDir URL is on a different host', () => {
-    // Defense in depth: even if URL construction ever yields a host that
-    // differs from config.url, the filter must still inspect the pathname.
-    mockFs.readdirSync.mockReturnValue(['sitemap-0.html', 'about.md']);
-    mockFs.statSync.mockReturnValue({
-      isDirectory: () => false,
-      isFile: () => true,
-    });
-
-    const sitemap = generateSitemap(baseConfig);
-
-    expect(sitemap).toContain('<loc>https://example.com/about</loc>');
-    expect(sitemap).not.toMatch(/<loc>[^<]*sitemap-0[^<]*<\/loc>/);
-  });
-
   it('should handle subdirectories recursively', () => {
     const files = ['index.md', 'blog', 'docs'];
     

--- a/src/core/sitemap.test.ts
+++ b/src/core/sitemap.test.ts
@@ -187,6 +187,73 @@ describe('generateSitemap', () => {
     expect(sitemap).toContain('<loc>https://example.com/products/</loc>');
   });
   
+  it('filters /sitemap, /sitemap-N, and /sitemap-index from config.pages', () => {
+    mockFs.readdirSync.mockReturnValue([]);
+    const configWithSitemapPages = {
+      ...baseConfig,
+      pages: [
+        { pathname: '/', title: 'Home', description: '', content: '' },
+        { pathname: '/about', title: 'About', description: '', content: '' },
+        { pathname: '/sitemap', title: '', description: '', content: '' },
+        { pathname: '/sitemap-0', title: '', description: '', content: '' },
+        { pathname: '/sitemap-1', title: '', description: '', content: '' },
+        { pathname: '/sitemap-index', title: '', description: '', content: '' },
+        { pathname: '/sitemap.xml', title: '', description: '', content: '' },
+        { pathname: '/sitemap-0.xml', title: '', description: '', content: '' },
+      ],
+    };
+
+    const sitemap = generateSitemap(configWithSitemapPages);
+
+    expect(sitemap).toContain('<loc>https://example.com/about</loc>');
+    expect(sitemap).not.toContain('/sitemap-0');
+    expect(sitemap).not.toContain('/sitemap-1');
+    expect(sitemap).not.toContain('/sitemap-index');
+    expect(sitemap).not.toContain('/sitemap.xml');
+    expect(sitemap).not.toMatch(/<loc>https:\/\/example\.com\/sitemap<\/loc>/);
+  });
+
+  it('preserves legitimate paths that start with sitemap- but are not sitemap files', () => {
+    mockFs.readdirSync.mockReturnValue([]);
+    const configWithSitemapNamedPages = {
+      ...baseConfig,
+      pages: [
+        { pathname: '/sitemap-guide', title: 'Sitemap Guide', description: '', content: '' },
+        { pathname: '/sitemap-tutorial', title: 'Tutorial', description: '', content: '' },
+        { pathname: '/sitemaps-explained', title: 'Explained', description: '', content: '' },
+        { pathname: '/sitemap-0', title: '', description: '', content: '' },
+      ],
+    };
+
+    const sitemap = generateSitemap(configWithSitemapNamedPages);
+
+    expect(sitemap).toContain('<loc>https://example.com/sitemap-guide</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/sitemap-tutorial</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/sitemaps-explained</loc>');
+    expect(sitemap).not.toContain('<loc>https://example.com/sitemap-0</loc>');
+  });
+
+  it('filters sitemap-named files discovered in contentDir', () => {
+    mockFs.readdirSync.mockReturnValue([
+      'index.md',
+      'about.md',
+      'sitemap-0.html',
+      'sitemap-index.html',
+      'sitemap-guide.md',
+    ]);
+    mockFs.statSync.mockReturnValue({
+      isDirectory: () => false,
+      isFile: () => true,
+    });
+
+    const sitemap = generateSitemap(baseConfig);
+
+    expect(sitemap).toContain('<loc>https://example.com/about</loc>');
+    expect(sitemap).toContain('<loc>https://example.com/sitemap-guide</loc>');
+    expect(sitemap).not.toContain('/sitemap-0');
+    expect(sitemap).not.toContain('/sitemap-index');
+  });
+
   it('should handle subdirectories recursively', () => {
     const files = ['index.md', 'blog', 'docs'];
     

--- a/src/core/sitemap.test.ts
+++ b/src/core/sitemap.test.ts
@@ -254,6 +254,21 @@ describe('generateSitemap', () => {
     expect(sitemap).not.toContain('/sitemap-index');
   });
 
+  it('still extracts a pathname when a contentDir URL is on a different host', () => {
+    // Defense in depth: even if URL construction ever yields a host that
+    // differs from config.url, the filter must still inspect the pathname.
+    mockFs.readdirSync.mockReturnValue(['sitemap-0.html', 'about.md']);
+    mockFs.statSync.mockReturnValue({
+      isDirectory: () => false,
+      isFile: () => true,
+    });
+
+    const sitemap = generateSitemap(baseConfig);
+
+    expect(sitemap).toContain('<loc>https://example.com/about</loc>');
+    expect(sitemap).not.toMatch(/<loc>[^<]*sitemap-0[^<]*<\/loc>/);
+  });
+
   it('should handle subdirectories recursively', () => {
     const files = ['index.md', 'blog', 'docs'];
     

--- a/src/core/sitemap.ts
+++ b/src/core/sitemap.ts
@@ -38,7 +38,18 @@ function escapeXml(str: string): string {
 }
 
 function isSitemapPathname(pathname: string): boolean {
-  return /^\/sitemap/i.test(pathname);
+  // Matches sitemap output produced by plugins like @astrojs/sitemap:
+  // /sitemap, /sitemap-0, /sitemap-1, /sitemap-index, /sitemap.xml, /sitemap-0.xml
+  // Does NOT match legitimate user pages like /sitemap-guide or /sitemaps-explained.
+  return /^\/sitemap(-\d+|-index)?(\.xml)?$/i.test(pathname);
+}
+
+function pathnameFromUrl(url: string, baseUrl: string): string {
+  if (url.startsWith(baseUrl)) {
+    const rest = url.slice(baseUrl.length);
+    return rest.startsWith('/') ? rest : `/${rest}`;
+  }
+  return url;
 }
 
 export function generateSitemap(config: ResolvedAeoConfig): string {
@@ -54,7 +65,10 @@ export function generateSitemap(config: ResolvedAeoConfig): string {
 
   // Add markdown/html files from content dir
   if (config.contentDir && existsSync(config.contentDir)) {
-    urls.push(...collectUrls(config.contentDir, config));
+    const contentUrls = collectUrls(config.contentDir, config).filter(
+      (url) => !isSitemapPathname(pathnameFromUrl(url, config.url))
+    );
+    urls.push(...contentUrls);
   }
 
   const lines: string[] = [

--- a/src/core/sitemap.ts
+++ b/src/core/sitemap.ts
@@ -37,12 +37,17 @@ function escapeXml(str: string): string {
     .replace(/'/g, '&apos;');
 }
 
+function isSitemapPathname(pathname: string): boolean {
+  return /^\/sitemap/i.test(pathname);
+}
+
 export function generateSitemap(config: ResolvedAeoConfig): string {
   const urls: string[] = [];
 
   // Add discovered pages from framework plugin
   if (config.pages && config.pages.length > 0) {
     for (const page of config.pages) {
+      if (isSitemapPathname(page.pathname)) continue;
       urls.push(`${config.url}${page.pathname === '/' ? '' : page.pathname}`);
     }
   }

--- a/src/core/sitemap.ts
+++ b/src/core/sitemap.ts
@@ -45,11 +45,15 @@ function isSitemapPathname(pathname: string): boolean {
 }
 
 function pathnameFromUrl(url: string, baseUrl: string): string {
-  if (url.startsWith(baseUrl)) {
-    const rest = url.slice(baseUrl.length);
-    return rest.startsWith('/') ? rest : `/${rest}`;
+  // Always extract the pathname portion so the sitemap-name filter still applies
+  // even when the URL doesn't share the configured base (e.g. a different host
+  // sneaks in via collectUrls). Falls back to the raw input only if URL parsing
+  // fails entirely, which the regex below will then ignore.
+  try {
+    return new URL(url, baseUrl).pathname;
+  } catch {
+    return url;
   }
-  return url;
 }
 
 export function generateSitemap(config: ResolvedAeoConfig): string {


### PR DESCRIPTION
## Problem

When `@astrojs/sitemap` (or similar plugins) is used alongside aeo.js, it generates `sitemap-index.xml`, `sitemap-0.xml`, `sitemap-1.xml`, etc. in the build output. If these pathnames reach `config.pages` — through manual configuration, a different framework plugin, or a future change in page discovery — `generateSitemap()` includes them as regular page URLs in the generated `sitemap.xml`.

## Real-world scenario

Discovered on a production Astro site using `@astrojs/sitemap`. The generated `sitemap-index.xml` was being indexed as a regular page by external crawlers.

## What changed

**File:** `src/core/sitemap.ts`

Added an `isSitemapPathname()` guard that filters plugin-generated sitemap pathnames before they enter the generated `sitemap.xml`. The filter applies to both `config.pages` and any URLs discovered via `collectUrls()` from `contentDir`.

The regex `/^\/sitemap(-\d+|-index)?(\.xml)?$/i` is intentionally **precise** — it matches:
- `/sitemap`
- `/sitemap-0`, `/sitemap-1`, … `/sitemap-N` (output of `@astrojs/sitemap`)
- `/sitemap-index`
- `/sitemap.xml`, `/sitemap-0.xml`, etc.

It does **not** match legitimate user pages like `/sitemap-guide`, `/sitemap-tutorial`, or `/sitemaps-explained`.

For cross-host URLs that may slip through `collectUrls()`, `pathnameFromUrl()` uses the WHATWG `URL` parser to always extract a real pathname before testing it.

## Tests

- `src/core/sitemap.test.ts` adds 4 new cases:
  1. filters `/sitemap`, `/sitemap-N`, `/sitemap-index`, `/sitemap.xml`, `/sitemap-0.xml` from `config.pages`
  2. preserves legitimate paths that start with `sitemap-` (e.g. `/sitemap-guide`)
  3. filters sitemap-named `.html`/`.md` files discovered in `contentDir`
  4. defense in depth: filter still applies when a URL has a different host than `config.url`

## Impact

- **No breaking changes** — only adds a filter, does not change any existing behavior for real pages
- **Targeted regex** — won't false-positive on legitimate `sitemap-*` content
- **Defense in depth** — covers `config.pages`, `contentDir` scan, and future cross-host edge cases