### PR TITLE
fix(ai-index): preserve Unicode keywords

### DIFF
--- a/src/core/ai-index.test.ts
+++ b/src/core/ai-index.test.ts
@@ -132,7 +132,9 @@ describe('generateAIIndex', () => {
       '\ucd5c\uc801\ud654',
       '\ucf58\ud150\uce20',
     ]));
-    expect(entry?.keywords).not.toEqual(expect.arrayContaining(['ai', 'seo', 'ux']));
+    expect(entry?.keywords).not.toContain('ai');
+    expect(entry?.keywords).not.toContain('seo');
+    expect(entry?.keywords).not.toContain('ux');
   });
 
   it('should handle pages without content', () => {

--- a/src/core/ai-index.test.ts
+++ b/src/core/ai-index.test.ts
@@ -104,6 +104,37 @@ describe('generateAIIndex', () => {
     expect(Array.isArray(homeEntry?.keywords)).toBe(true);
   });
 
+  it('should preserve Unicode keywords from international content', () => {
+    const config: ResolvedAeoConfig = {
+      ...baseConfig,
+      pages: [
+        {
+          pathname: '/international',
+          title: 'International',
+          content: [
+            'caf\u00e9 r\u00e9sum\u00e9 na\u00efve fa\u00e7ade',
+            '\ud55c\uad6d\uc5b4 \uac80\uc0c9 \ucd5c\uc801\ud654 \ucf58\ud150\uce20 \ud55c\uad6d\uc5b4 \uac80\uc0c9',
+            'AI SEO UX',
+          ].join(' '),
+        },
+      ],
+    };
+
+    const result = generateAIIndex(config);
+    const index = JSON.parse(result);
+    const entry = index.entries.find((e: any) => e.url === 'https://example.com/international');
+
+    expect(entry?.keywords).toEqual(expect.arrayContaining([
+      'caf\u00e9',
+      'r\u00e9sum\u00e9',
+      '\ud55c\uad6d\uc5b4',
+      '\uac80\uc0c9',
+      '\ucd5c\uc801\ud654',
+      '\ucf58\ud150\uce20',
+    ]));
+    expect(entry?.keywords).not.toEqual(expect.arrayContaining(['ai', 'seo', 'ux']));
+  });
+
   it('should handle pages without content', () => {
     const result = generateAIIndex(baseConfig);
     const index = JSON.parse(result);

--- a/src/core/ai-index.ts
+++ b/src/core/ai-index.ts
@@ -6,14 +6,17 @@ import { parseFrontmatter, extractTitle } from './utils';
 
 function extractKeywords(content: string): string[] {
   const words = content
+    .normalize('NFC')
     .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, ' ')
-    .split(/\s+/)
-    .filter(word => word.length > 3);
+    .match(/[\p{L}\p{N}\p{M}]+(?:[-'][\p{L}\p{N}\p{M}]+)*/gu) || [];
   
   const wordCount: Record<string, number> = {};
   
   for (const word of words) {
+    const isAscii = /^[a-z0-9'-]+$/i.test(word);
+    const minLength = isAscii ? 4 : 2;
+    if (Array.from(word).length < minLength) continue;
+
     wordCount[word] = (wordCount[word] || 0) + 1;
   }
   

--- a/src/core/ai-index.ts
+++ b/src/core/ai-index.ts
@@ -13,7 +13,7 @@ function extractKeywords(content: string): string[] {
   const wordCount: Record<string, number> = {};
   
   for (const word of words) {
-    const isAscii = /^[a-z0-9'-]+$/i.test(word);
+    const isAscii = /^[a-z0-9'-]+$/.test(word);
     const minLength = isAscii ? 4 : 2;
     if (Array.from(word).length < minLength) continue;
 


### PR DESCRIPTION
Preserves Unicode words in ai-index keyword extraction instead of stripping non-ASCII content. Keeps short ASCII tokens filtered. Tested with targeted Vitest, full Vitest, typecheck, and build.
