### PR TITLE
ci: skip Cloudflare deploy on Dependabot PRs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -46,8 +46,11 @@ jobs:
           command: pages deploy website/dist --project-name=aeojs --branch=main
 
       # Preview deploy (pull requests)
+      # Skipped for Dependabot PRs: GitHub blocks repository secrets from
+      # Dependabot-authored runs, so CLOUDFLARE_API_TOKEN is empty and Wrangler
+      # cannot deploy. The build step above still runs as a sanity check.
       - name: Deploy Preview
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         uses: cloudflare/wrangler-action@v3
         id: deploy-preview
         with:
@@ -57,7 +60,7 @@ jobs:
 
       # Comment preview URL on the PR
       - name: Comment Preview URL
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
## Problem

PRs #20–#25 (all Dependabot website-deps bumps) are blocked on the **Deploy Docs to Cloudflare Pages** check. Wrangler errors with:

> In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work.

Root cause: GitHub Actions [blocks repository secrets from runs authored by \`dependabot[bot]\`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets) as a security measure. So \`secrets.CLOUDFLARE_API_TOKEN\` is empty on those runs and the deploy step fails.

## Fix

Skip the **Deploy Preview** and **Comment Preview URL** steps when \`github.actor == 'dependabot[bot]'\`. The **Install and build** step still runs, so we keep the sanity check that the dep bump actually compiles.

## Why not pass the token via dependabot secrets?

Could work (\`Settings → Secrets → Dependabot\`), but it requires duplicating the secret and slightly broadens the trust surface for Dependabot. For a docs preview, it's not worth that — we don't need a per-PR preview from Dependabot bumps.

## After this merges

The 6 stuck Dependabot PRs need to either:
- be rebased onto main (\`@dependabot rebase\` comment) so they pick up the new workflow, or
- be admin-merged now since we know they're safe (green Greptile / Vercel / Graphite, just dep bumps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)