### PR TITLE
chore: ignore bun.lock to keep npm as the single source of truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@ dist
 .env
 .DS_Store
 
+# Repo standardizes on npm (package-lock.json). Prevent stray bun.lock files
+# from polluting the repo when contributors run `bun install` locally.
+bun.lock
+bun.lockb
+**/bun.lock
+**/bun.lockb
+
 # Demo artifacts
 demo/*/node_modules
 demo/*/dist


### PR DESCRIPTION
## Why

This repo uses npm:
- `publish.yml` runs \`npm ci && npm run build && npm publish --provenance --access public\`
- `deploy-docs.yml` runs \`npm install && npm run build\` in \`website/\`
- All 8 lock files in the tree are \`package-lock.json\`

But contributors who default to bun (myself included) end up generating \`bun.lock\` files at the root and in \`website/\` when running \`bun install\` to debug. Those files can drift from \`package-lock.json\` and silently get committed in a future PR.

## What

Adds bun lock-file patterns to \`.gitignore\` at every depth:

\`\`\`
bun.lock
bun.lockb
**/bun.lock
**/bun.lockb
\`\`\`

This way:
- npm remains the single source of truth on disk and in CI
- Contributors who prefer bun can still run \`bun install\` locally without polluting the repo
- No CI changes, no toolchain change, no published-package change

## Notes

- The two stray \`bun.lock\` files I had locally were never committed — \`git ls-files\` confirms only \`package-lock.json\` is tracked. This PR is purely defensive.
- A full migration to bun (replacing all 8 lock files + updating CI) would be a separate, intentional decision and is **not** what this PR does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)