### PR TITLE
fix(widget): add accessible names to toggle buttons

### DIFF
--- a/src/widget/core.ts
+++ b/src/widget/core.ts
@@ -82,24 +82,28 @@ export class AeoWidget {
 
     this.toggleElement = document.createElement('div');
     const sizeClass = size === 'small' ? ' aeo-small' : size === 'icon-only' ? ' aeo-icon-only' : '';
+    const humanLabel = this.config.widget?.humanLabel || 'Human';
+    const aiLabel = this.config.widget?.aiLabel || 'AI';
     this.toggleElement.className = `aeo-toggle aeo-${position}${sizeClass}`;
     this.toggleElement.innerHTML = `
-      <div class="aeo-toggle-inner">
+      <div class="aeo-toggle-inner" role="group" aria-label="View mode">
         <button
           class="aeo-toggle-btn aeo-human-btn aeo-active"
           data-mode="human"
-          aria-label="${this.config.widget?.humanLabel || 'Human'} mode"
+          aria-label="${this.escHtml(humanLabel)} mode"
+          aria-pressed="true"
         >
           ${icons.human}
-          <span>${this.config.widget?.humanLabel || 'Human'}</span>
+          <span>${this.escHtml(humanLabel)}</span>
         </button>
         <button
           class="aeo-toggle-btn aeo-ai-btn"
           data-mode="ai"
-          aria-label="${this.config.widget?.aiLabel || 'AI'} mode"
+          aria-label="${this.escHtml(aiLabel)} mode"
+          aria-pressed="false"
         >
           ${icons.ai}
-          <span>${this.config.widget?.aiLabel || 'AI'}</span>
+          <span>${this.escHtml(aiLabel)}</span>
         </button>
       </div>
     `;
@@ -155,9 +159,13 @@ export class AeoWidget {
     if (this.isAIMode) {
       humanBtn?.classList.remove('aeo-active');
       aiBtn?.classList.add('aeo-active');
+      humanBtn?.setAttribute('aria-pressed', 'false');
+      aiBtn?.setAttribute('aria-pressed', 'true');
     } else {
       humanBtn?.classList.add('aeo-active');
       aiBtn?.classList.remove('aeo-active');
+      humanBtn?.setAttribute('aria-pressed', 'true');
+      aiBtn?.setAttribute('aria-pressed', 'false');
     }
   }
 

--- a/src/widget/core.ts
+++ b/src/widget/core.ts
@@ -85,11 +85,19 @@ export class AeoWidget {
     this.toggleElement.className = `aeo-toggle aeo-${position}${sizeClass}`;
     this.toggleElement.innerHTML = `
       <div class="aeo-toggle-inner">
-        <button class="aeo-toggle-btn aeo-human-btn aeo-active" data-mode="human">
+        <button
+          class="aeo-toggle-btn aeo-human-btn aeo-active"
+          data-mode="human"
+          aria-label="${this.config.widget?.humanLabel || 'Human'} mode"
+        >
           ${icons.human}
           <span>${this.config.widget?.humanLabel || 'Human'}</span>
         </button>
-        <button class="aeo-toggle-btn aeo-ai-btn" data-mode="ai">
+        <button
+          class="aeo-toggle-btn aeo-ai-btn"
+          data-mode="ai"
+          aria-label="${this.config.widget?.aiLabel || 'AI'} mode"
+        >
           ${icons.ai}
           <span>${this.config.widget?.aiLabel || 'AI'}</span>
         </button>


### PR DESCRIPTION
## Summary
Fixes accessibility issue where widget toggle buttons had no accessible name in some layouts, causing screen readers to announce only “button”.

## What changed
- Added `aria-label` to `.aeo-human-btn` and `.aeo-ai-btn` in the widget toggle.
- Labels are derived from configured button text (`humanLabel` / `aiLabel`) with `mode` suffix.

## Why
In icon-only mode, visible text can be hidden, so buttons may lose an accessible name for assistive technologies.  
This ensures both toggle buttons are always announced with meaningful names. 
<img width="669" height="696" alt="Captura de tela 2026-05-08 014648" src="https://github.com/user-attachments/assets/ff34a181-3e28-4701-807b-41fb2a41d3b9" />


## Validation
- `npm run build` ✅
- `npm run lint` ✅
- `npx vitest run src/widget/core.test.ts` ✅
- `npm run test -- --run` ⚠️ 1 unrelated pre-existing failure in `src/plugins/angular.test.ts` (`should scan Angular routes from source`)
