### PR TITLE
docs: clarify off-site AI visibility limits (closes #53)

### DIFF
--- a/website/src/content/docs/getting-started/introduction.mdx
+++ b/website/src/content/docs/getting-started/introduction.mdx
@@ -3,6 +3,8 @@ title: Introduction
 description: What is aeo.js and why you need Answer Engine Optimization.
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 ![aeo.js in action](/example.webp)
 
 ## What is Answer Engine Optimization?
@@ -29,6 +31,30 @@ AI crawlers and LLMs look for specific files and formats that most websites don'
 2. **Build** your site as usual
 3. **aeo.js** scans your output, extracts content, and generates all AEO files
 4. The optional **widget** lets visitors toggle between human and AI views of your pages
+
+## Scope: what aeo.js does and doesn't influence
+
+AEO is the **on-site** half of being discoverable by AI engines — there's an off-site half that aeo.js cannot reach. Setting expectations upfront so you can plan a full strategy:
+
+<Aside type="note" title="What aeo.js does well">
+Improves machine-readable access to **your own site**:
+
+- generates `llms.txt`, `llms-full.txt`, `ai-index.json`, raw markdown copies, JSON-LD schema, and a sitemap
+- structures content so AI crawlers can fetch, parse, and quote it
+- audits and scores your page-level citability so you know where to improve
+</Aside>
+
+<Aside type="caution" title="What aeo.js cannot influence">
+Off-site signals that AI engines also weigh:
+
+- **third-party mentions and reviews** of your product across the web
+- **inbound links** and how reputable the linking domains are
+- **community discussions** (Reddit, Hacker News, X, niche forums) and how often you're cited there
+- **model training data** — what an LLM "already knows" about you from its pre-training cutoff
+- **freshness signals** outside your control (independent news, blog roundups, podcasts)
+</Aside>
+
+Think of aeo.js as a strong foundation — necessary but not sufficient. For full AEO coverage, pair it with the off-site work above: PR, community engagement, and being mentioned where your customers research.
 
 ## Supported Frameworks
 


### PR DESCRIPTION
## Summary

Implements [#53](https://github.com/multivmlabs/aeo.js/issues/53) from @KimHyeongRae0 — adds an explicit Scope section to the introduction page so users understand which half of AEO aeo.js owns vs which half lives off-site.

## What changed

[`website/src/content/docs/getting-started/introduction.mdx`](website/src/content/docs/getting-started/introduction.mdx) gains a new "## Scope: what aeo.js does and doesn't influence" section, placed between "How it works" and "Supported Frameworks". Two Starlight Asides:

**What aeo.js does well** (type: note):
- generates llms.txt, llms-full.txt, ai-index.json, raw markdown, JSON-LD, sitemap
- structures content so AI crawlers can fetch, parse, and quote it
- audits and scores page-level citability

**What aeo.js cannot influence** (type: caution):
- third-party mentions and reviews
- inbound links / domain authority
- community discussions (Reddit, HN, X, niche forums)
- model training data
- off-site freshness signals (news, podcasts, blog roundups)

Closes with a "necessary but not sufficient" framing so users pair aeo.js with the off-site work for full coverage.

## Test plan

- [x] `bun run build` — 21 pages, clean
- [ ] Manual: visit `/getting-started/introduction/` in the dev server and verify the Asides render correctly

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)