### PR TITLE
feat: SvelteKit integration (aeo.js/sveltekit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ export default defineNuxtConfig({
 });
 ```
 
+### SvelteKit
+
+```json
+{
+  "scripts": {
+    "postbuild": "node -e \"import('aeo.js/sveltekit').then(m => m.postBuild({ title: 'My Site', url: 'https://mysite.com' }))\""
+  }
+}
+```
+
 ### Angular
 
 ```json
@@ -147,6 +157,7 @@ npx aeo.js check
 | Next.js | `aeo.js/next` |
 | Vite | `aeo.js/vite` |
 | Nuxt | `aeo.js/nuxt` |
+| SvelteKit | `aeo.js/sveltekit` |
 | Angular | `aeo.js/angular` |
 | Webpack | `aeo.js/webpack` |
 | CLI | `npx aeo.js generate` |

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
       "import": "./dist/angular.mjs",
       "require": "./dist/angular.js"
     },
+    "./sveltekit": {
+      "types": "./dist/sveltekit.d.ts",
+      "import": "./dist/sveltekit.mjs",
+      "require": "./dist/sveltekit.js"
+    },
     "./react": {
       "types": "./dist/react.d.ts",
       "import": "./dist/react.mjs",

--- a/src/plugins/sveltekit.test.ts
+++ b/src/plugins/sveltekit.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { postBuild, generate, getWidgetScript } from './sveltekit';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let projectDir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  projectDir = mkdtempSync(join(tmpdir(), 'aeo-sveltekit-'));
+  process.chdir(projectDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+function writePage(relDir: string, html: string): void {
+  const dir = join(projectDir, relDir);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'index.html'), html, 'utf-8');
+}
+
+const HTML = (title: string) =>
+  `<!doctype html><html><head><title>${title}</title><meta name="description" content="Description for ${title} that is long enough."></head><body><h1>${title}</h1><p>Some real content about ${title} for extraction purposes.</p></body></html>`;
+
+describe('getWidgetScript', () => {
+  it('returns a module script with the widget config', () => {
+    const script = getWidgetScript({ title: 'My Site', url: 'https://mysite.com' });
+    expect(script).toContain('<script type="module">');
+    expect(script).toContain("import('aeo.js/widget')");
+    expect(script).toContain('My Site');
+  });
+
+  it('returns empty string when the widget is disabled', () => {
+    expect(getWidgetScript({ widget: { enabled: false } })).toBe('');
+  });
+});
+
+describe('generate (source routes)', () => {
+  it('discovers routes from src/routes, skipping dynamic and group segments', async () => {
+    const routes = join(projectDir, 'src', 'routes');
+    mkdirSync(join(routes, 'about'), { recursive: true });
+    mkdirSync(join(routes, '(marketing)', 'pricing'), { recursive: true });
+    mkdirSync(join(routes, 'blog', '[slug]'), { recursive: true });
+    writeFileSync(join(routes, '+page.svelte'), '<h1>Home</h1>');
+    writeFileSync(join(routes, 'about', '+page.svelte'), '<h1>About</h1>');
+    writeFileSync(join(routes, '(marketing)', 'pricing', '+page.svelte'), '<h1>Pricing</h1>');
+    writeFileSync(join(routes, 'blog', '[slug]', '+page.svelte'), '<h1>Post</h1>');
+
+    await generate({ title: 'My Site', url: 'https://mysite.com', widget: { enabled: false } });
+
+    const llms = readFileSync(join(projectDir, 'static', 'llms.txt'), 'utf-8');
+    expect(llms).toContain('/about');
+    // (marketing) group does not contribute a URL segment
+    expect(llms).toContain('/pricing');
+    expect(llms).not.toContain('(marketing)');
+    expect(llms).not.toContain('[slug]');
+  });
+});
+
+describe('postBuild (adapter-static)', () => {
+  it('scans build/ output, generates AEO files, and injects the widget', async () => {
+    writePage('build', HTML('Home'));
+    writePage('build/about', HTML('About'));
+
+    await postBuild({ title: 'My Site', url: 'https://mysite.com' });
+
+    expect(existsSync(join(projectDir, 'build', 'robots.txt'))).toBe(true);
+    expect(existsSync(join(projectDir, 'build', 'llms.txt'))).toBe(true);
+    expect(existsSync(join(projectDir, 'build', 'sitemap.xml'))).toBe(true);
+
+    const llms = readFileSync(join(projectDir, 'build', 'llms.txt'), 'utf-8');
+    expect(llms).toContain('/about');
+
+    const home = readFileSync(join(projectDir, 'build', 'index.html'), 'utf-8');
+    expect(home).toContain("import('aeo.js/widget')");
+  });
+
+  it('does not inject the widget when disabled', async () => {
+    writePage('build', HTML('Home'));
+
+    await postBuild({ title: 'My Site', url: 'https://mysite.com', widget: { enabled: false } });
+
+    const home = readFileSync(join(projectDir, 'build', 'index.html'), 'utf-8');
+    expect(home).not.toContain('aeo.js/widget');
+  });
+
+  it('does not double-inject the widget on repeated runs', async () => {
+    writePage('build', HTML('Home'));
+
+    await postBuild({ title: 'My Site', url: 'https://mysite.com' });
+    await postBuild({ title: 'My Site', url: 'https://mysite.com' });
+
+    const home = readFileSync(join(projectDir, 'build', 'index.html'), 'utf-8');
+    expect(home.match(/aeo\.js\/widget/g)).toHaveLength(1);
+  });
+
+  it('falls back to .svelte-kit output for non-static adapters', async () => {
+    writePage('.svelte-kit/output/client', '<!doctype html><html><body></body></html>');
+    // remove the placeholder html — client dir usually only has assets
+    rmSync(join(projectDir, '.svelte-kit', 'output', 'client', 'index.html'));
+    writePage('.svelte-kit/output/prerendered/pages', HTML('Home'));
+
+    await postBuild({ title: 'My Site', url: 'https://mysite.com', widget: { enabled: false } });
+
+    const outDir = join(projectDir, '.svelte-kit', 'output', 'client');
+    expect(existsSync(join(outDir, 'robots.txt'))).toBe(true);
+
+    const llms = readFileSync(join(outDir, 'llms.txt'), 'utf-8');
+    expect(llms).toContain('Home');
+  });
+});

--- a/src/plugins/sveltekit.test.ts
+++ b/src/plugins/sveltekit.test.ts
@@ -113,4 +113,56 @@ describe('postBuild (adapter-static)', () => {
     const llms = readFileSync(join(outDir, 'llms.txt'), 'utf-8');
     expect(llms).toContain('Home');
   });
+
+  it('injects the widget into prerendered/pages for non-static adapters', async () => {
+    writePage('.svelte-kit/output/client', '<!doctype html><html><body></body></html>');
+    rmSync(join(projectDir, '.svelte-kit', 'output', 'client', 'index.html'));
+    writePage('.svelte-kit/output/prerendered/pages', HTML('Home'));
+
+    await postBuild({ title: 'My Site', url: 'https://mysite.com' });
+
+    const prerenderedHome = readFileSync(
+      join(projectDir, '.svelte-kit', 'output', 'prerendered', 'pages', 'index.html'),
+      'utf-8',
+    );
+    expect(prerenderedHome).toContain("import('aeo.js/widget')");
+  });
+
+  it('config.pages overrides take priority over auto-discovered pages with the same pathname', async () => {
+    // Auto-discovered page has content extracted from HTML; user-provided page
+    // explicitly sets a custom title that should win.
+    writePage('build', HTML('Auto Home Title'));
+    writePage('build/about', HTML('Auto About'));
+
+    await postBuild({
+      title: 'My Site',
+      url: 'https://mysite.com',
+      widget: { enabled: false },
+      pages: [
+        { pathname: '/', title: 'Custom Home Title', description: 'Custom home description.' },
+      ],
+    });
+
+    const llms = readFileSync(join(projectDir, 'build', 'llms.txt'), 'utf-8');
+    expect(llms).toContain('Custom Home Title');
+    expect(llms).not.toContain('Auto Home Title');
+  });
+});
+
+describe('getWidgetScript (script tag safety)', () => {
+  it('escapes </script> sequences in serialized config', () => {
+    const script = getWidgetScript({
+      title: 'Safe</script><script>alert(1)',
+      url: 'https://mysite.com',
+    });
+    // Extract just the JSON config argument — everything between `config: ` and
+    // the closing `}` of the AeoWidget call. The raw sequence </script> must
+    // not appear there; it would prematurely close the enclosing script element.
+    const configMatch = script.match(/new AeoWidget\(\{ config: (.+?) \}\)/s);
+    expect(configMatch).not.toBeNull();
+    const jsonPart = configMatch![1];
+    expect(jsonPart).not.toContain('</script>');
+    // The title value should be present in its unicode-escaped form.
+    expect(jsonPart).toContain('\\u003c/script\\u003e');
+  });
 });

--- a/src/plugins/sveltekit.ts
+++ b/src/plugins/sveltekit.ts
@@ -136,7 +136,10 @@ export function getWidgetScript(config: AeoConfig = {}): string {
     description: resolvedConfig.description,
     url: resolvedConfig.url,
     widget: resolvedConfig.widget,
-  });
+  })
+    .replace(/&/g, '\\u0026')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
 
   return `<script type="module">
 import('aeo.js/widget').then(({ AeoWidget }) => {
@@ -217,14 +220,21 @@ export async function postBuild(config: AeoConfig & { injectWidget?: boolean } =
 
   const sourcePages = scanSvelteKitRoutes(projectRoot);
 
-  // Merge: build output (with content) takes priority over source-scanned routes
-  const allPages = [...discovered, ...sourcePages, ...(config.pages || [])];
+  // Merge priority (highest to lowest):
+  //   1. config.pages (explicit user overrides — always win)
+  //   2. discovered HTML pages with content
+  //   3. source-scanned routes (lowest priority)
   const pageMap = new Map<string, PageEntry>();
-  for (const page of allPages) {
+  // Layer in discovered and source pages first (lower priority)
+  for (const page of [...discovered, ...sourcePages]) {
     const existing = pageMap.get(page.pathname);
     if (!existing || (page.content && !existing.content)) {
       pageMap.set(page.pathname, page);
     }
+  }
+  // User-provided pages always win — overwrite whatever was discovered
+  for (const page of config.pages || []) {
+    pageMap.set(page.pathname, page);
   }
 
   for (const page of pageMap.values()) {
@@ -251,7 +261,16 @@ export async function postBuild(config: AeoConfig & { injectWidget?: boolean } =
   }
 
   if (config.injectWidget !== false && resolvedConfig.widget.enabled) {
-    const injected = injectWidgetIntoHtml(outputDir, config);
+    // For non-static adapters the client dir only holds JS/CSS bundles.
+    // Prerendered HTML lives under .svelte-kit/output/prerendered/pages.
+    const widgetDirs: string[] = [outputDir];
+    if (outputDir.includes('.svelte-kit')) {
+      widgetDirs.push(join(projectRoot, '.svelte-kit', 'output', 'prerendered', 'pages'));
+    }
+    let injected = 0;
+    for (const dir of widgetDirs) {
+      injected += injectWidgetIntoHtml(dir, config);
+    }
     if (injected > 0) {
       console.log(`[aeo.js] Injected widget into ${injected} page(s)`);
     }

--- a/src/plugins/sveltekit.ts
+++ b/src/plugins/sveltekit.ts
@@ -209,9 +209,10 @@ export async function postBuild(config: AeoConfig & { injectWidget?: boolean } =
 
   const buildPages = scanHtmlOutput(outputDir);
 
-  // Non-static adapters keep prerendered pages in a separate directory
+  // Non-static adapters keep prerendered pages in a separate directory.
+  // Check existence rather than string-matching the path so custom outDir still works.
   const prerenderedDir = join(projectRoot, '.svelte-kit', 'output', 'prerendered', 'pages');
-  const prerenderedPages = outputDir.includes('.svelte-kit') ? scanHtmlOutput(prerenderedDir) : [];
+  const prerenderedPages = existsSync(prerenderedDir) ? scanHtmlOutput(prerenderedDir) : [];
 
   const discovered = [...buildPages, ...prerenderedPages];
   if (discovered.length > 0) {
@@ -264,8 +265,8 @@ export async function postBuild(config: AeoConfig & { injectWidget?: boolean } =
     // For non-static adapters the client dir only holds JS/CSS bundles.
     // Prerendered HTML lives under .svelte-kit/output/prerendered/pages.
     const widgetDirs: string[] = [outputDir];
-    if (outputDir.includes('.svelte-kit')) {
-      widgetDirs.push(join(projectRoot, '.svelte-kit', 'output', 'prerendered', 'pages'));
+    if (existsSync(prerenderedDir)) {
+      widgetDirs.push(prerenderedDir);
     }
     let injected = 0;
     for (const dir of widgetDirs) {
@@ -298,10 +299,19 @@ export async function generate(config: AeoConfig = {}): Promise<void> {
     }
   }
 
+  // Merge with same priority as postBuild: discovered first, then config.pages win.
+  const pageMap = new Map<string, PageEntry>();
+  for (const page of discoveredPages) {
+    pageMap.set(page.pathname, page);
+  }
+  for (const page of config.pages || []) {
+    pageMap.set(page.pathname, page);
+  }
+
   const resolvedConfig = resolveConfig({
     ...config,
     outDir: config.outDir || 'static',
-    pages: [...(config.pages || []), ...discoveredPages],
+    pages: Array.from(pageMap.values()),
   });
 
   const result = await generateAEOFiles(resolvedConfig);

--- a/src/plugins/sveltekit.ts
+++ b/src/plugins/sveltekit.ts
@@ -78,6 +78,10 @@ function detectSvelteKitOutputDir(projectRoot: string): string {
   const clientDir = join(projectRoot, '.svelte-kit', 'output', 'client');
   if (existsSync(clientDir)) return clientDir;
 
+  console.warn(
+    '[aeo.js] Could not detect SvelteKit output directory (build/ and .svelte-kit/output/client are absent). ' +
+      'Pass outDir explicitly or run your build first.',
+  );
   return staticBuild;
 }
 

--- a/src/plugins/sveltekit.ts
+++ b/src/plugins/sveltekit.ts
@@ -1,0 +1,295 @@
+import { generateAEOFiles } from '../core/generate';
+import { resolveConfig } from '../core/utils';
+import type { AeoConfig, PageEntry } from '../types';
+import { extractTextFromHtml, extractTitle, extractDescription } from '../core/html-extract';
+import { join } from 'path';
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+
+/**
+ * Scan SvelteKit routes from src/routes.
+ * Directories map to URL segments; (group) segments are transparent and
+ * dynamic segments ([param], [...rest]) are skipped since they can't be
+ * enumerated statically. A directory is a page when it contains
+ * +page.svelte (or +page.md / +page.svx via mdsvex).
+ */
+function scanSvelteKitRoutes(projectRoot: string): PageEntry[] {
+  const pages: PageEntry[] = [];
+  const routesDir = join(projectRoot, 'src', 'routes');
+  if (!existsSync(routesDir)) {
+    pages.push({ pathname: '/' });
+    return pages;
+  }
+
+  const PAGE_FILES = ['+page.svelte', '+page.md', '+page.svx'];
+
+  function walk(dir: string, basePath: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+
+    if (entries.some((e) => PAGE_FILES.includes(e))) {
+      const pathname = basePath || '/';
+      if (!pages.some((p) => p.pathname === pathname)) {
+        const segment = pathname.split('/').filter(Boolean).pop();
+        pages.push({
+          pathname,
+          title: segment ? segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' ') : undefined,
+        });
+      }
+    }
+
+    for (const entry of entries) {
+      if (entry.startsWith('.') || entry.startsWith('[')) continue;
+      const fullPath = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (!stat.isDirectory()) continue;
+      // Route groups like (marketing) don't contribute a URL segment
+      const segment = entry.startsWith('(') && entry.endsWith(')') ? '' : `/${entry}`;
+      walk(fullPath, `${basePath}${segment}`);
+    }
+  }
+
+  walk(routesDir, '');
+
+  if (!pages.some((p) => p.pathname === '/')) {
+    pages.unshift({ pathname: '/' });
+  }
+
+  return pages;
+}
+
+/**
+ * Detect the SvelteKit output directory.
+ * adapter-static writes to build/; other adapters keep prerendered pages
+ * under .svelte-kit/output and serve static assets from the client dir.
+ */
+function detectSvelteKitOutputDir(projectRoot: string): string {
+  const staticBuild = join(projectRoot, 'build');
+  if (existsSync(staticBuild)) return staticBuild;
+
+  const clientDir = join(projectRoot, '.svelte-kit', 'output', 'client');
+  if (existsSync(clientDir)) return clientDir;
+
+  return staticBuild;
+}
+
+/** Scan a directory tree for prerendered HTML pages. */
+function scanHtmlOutput(outputDir: string): PageEntry[] {
+  const pages: PageEntry[] = [];
+  if (!existsSync(outputDir)) return pages;
+
+  function walk(dir: string, basePath: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory() && !entry.startsWith('.') && entry !== '_app') {
+        walk(fullPath, `${basePath}/${entry}`);
+      } else if (entry.endsWith('.html') && entry !== '404.html' && entry !== '500.html') {
+        try {
+          const html = readFileSync(fullPath, 'utf-8');
+          const pathname = entry === 'index.html' ? basePath || '/' : `${basePath}/${entry.replace('.html', '')}`;
+          pages.push({
+            pathname,
+            title: extractTitle(html),
+            description: extractDescription(html),
+            content: extractTextFromHtml(html),
+          });
+        } catch {
+          /* skip */
+        }
+      }
+    }
+  }
+
+  walk(outputDir, '');
+  return pages;
+}
+
+/**
+ * Generate a widget script tag to inject into prerendered HTML.
+ */
+export function getWidgetScript(config: AeoConfig = {}): string {
+  const resolvedConfig = resolveConfig(config);
+  if (!resolvedConfig.widget.enabled) return '';
+
+  const widgetConfig = JSON.stringify({
+    title: resolvedConfig.title,
+    description: resolvedConfig.description,
+    url: resolvedConfig.url,
+    widget: resolvedConfig.widget,
+  });
+
+  return `<script type="module">
+import('aeo.js/widget').then(({ AeoWidget }) => {
+  try {
+    new AeoWidget({ config: ${widgetConfig} });
+  } catch (e) {
+    console.warn('[aeo.js] Widget initialization failed:', e);
+  }
+}).catch(() => {});
+</script>`;
+}
+
+/** Inject the widget script into every prerendered HTML page that lacks it. */
+function injectWidgetIntoHtml(outputDir: string, config: AeoConfig): number {
+  const script = getWidgetScript(config);
+  if (!script) return 0;
+
+  let injected = 0;
+  function walk(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory() && !entry.startsWith('.') && entry !== '_app') {
+        walk(fullPath);
+      } else if (entry.endsWith('.html') && entry !== '404.html' && entry !== '500.html') {
+        try {
+          const html = readFileSync(fullPath, 'utf-8');
+          if (html.includes('aeo.js/widget') || !html.includes('</body>')) continue;
+          writeFileSync(fullPath, html.replace('</body>', `${script}\n</body>`), 'utf-8');
+          injected++;
+        } catch {
+          /* skip */
+        }
+      }
+    }
+  }
+
+  walk(outputDir);
+  return injected;
+}
+
+/**
+ * Post-build function for SvelteKit projects.
+ * Scans the build output (adapter-static's build/ or .svelte-kit/output)
+ * for prerendered HTML, generates AEO files alongside it, and optionally
+ * injects the widget into every prerendered page.
+ *
+ * Usage in package.json:
+ *   "postbuild": "node -e \"import('aeo.js/sveltekit').then(m => m.postBuild({ title: 'My Site', url: 'https://mysite.com' }))\""
+ */
+export async function postBuild(config: AeoConfig & { injectWidget?: boolean } = {}): Promise<void> {
+  const projectRoot = process.cwd();
+  const outputDir = config.outDir || detectSvelteKitOutputDir(projectRoot);
+
+  console.log(`[aeo.js] Scanning SvelteKit build output: ${outputDir}`);
+
+  const buildPages = scanHtmlOutput(outputDir);
+
+  // Non-static adapters keep prerendered pages in a separate directory
+  const prerenderedDir = join(projectRoot, '.svelte-kit', 'output', 'prerendered', 'pages');
+  const prerenderedPages = outputDir.includes('.svelte-kit') ? scanHtmlOutput(prerenderedDir) : [];
+
+  const discovered = [...buildPages, ...prerenderedPages];
+  if (discovered.length > 0) {
+    console.log(`[aeo.js] Discovered ${discovered.length} pages from SvelteKit build output`);
+  }
+
+  const sourcePages = scanSvelteKitRoutes(projectRoot);
+
+  // Merge: build output (with content) takes priority over source-scanned routes
+  const allPages = [...discovered, ...sourcePages, ...(config.pages || [])];
+  const pageMap = new Map<string, PageEntry>();
+  for (const page of allPages) {
+    const existing = pageMap.get(page.pathname);
+    if (!existing || (page.content && !existing.content)) {
+      pageMap.set(page.pathname, page);
+    }
+  }
+
+  for (const page of pageMap.values()) {
+    if (page.pathname === '/' && !page.title && config.title) {
+      page.title = config.title;
+    }
+    if (!page.description && config.description) {
+      page.description = config.description;
+    }
+  }
+
+  const resolvedConfig = resolveConfig({
+    ...config,
+    outDir: outputDir,
+    pages: Array.from(pageMap.values()),
+  });
+
+  const result = await generateAEOFiles(resolvedConfig);
+  if (result.files.length > 0) {
+    console.log(`[aeo.js] Generated ${result.files.length} files`);
+  }
+  if (result.errors.length > 0) {
+    console.error('[aeo.js] Errors:', result.errors);
+  }
+
+  if (config.injectWidget !== false && resolvedConfig.widget.enabled) {
+    const injected = injectWidgetIntoHtml(outputDir, config);
+    if (injected > 0) {
+      console.log(`[aeo.js] Injected widget into ${injected} page(s)`);
+    }
+  }
+}
+
+/**
+ * Generate AEO files for SvelteKit from source routes only (no build output).
+ * Writes into static/ so the files ship with any adapter. Useful for dev.
+ */
+export async function generate(config: AeoConfig = {}): Promise<void> {
+  const projectRoot = process.cwd();
+  const discoveredPages = scanSvelteKitRoutes(projectRoot);
+
+  if (discoveredPages.length > 0) {
+    console.log(`[aeo.js] Discovered ${discoveredPages.length} routes from SvelteKit source`);
+  }
+
+  for (const page of discoveredPages) {
+    if (page.pathname === '/' && !page.title && config.title) {
+      page.title = config.title;
+    }
+    if (!page.description && config.description) {
+      page.description = config.description;
+    }
+  }
+
+  const resolvedConfig = resolveConfig({
+    ...config,
+    outDir: config.outDir || 'static',
+    pages: [...(config.pages || []), ...discoveredPages],
+  });
+
+  const result = await generateAEOFiles(resolvedConfig);
+  if (result.files.length > 0) {
+    console.log(`[aeo.js] Generated ${result.files.length} files`);
+  }
+  if (result.errors.length > 0) {
+    console.error('[aeo.js] Errors:', result.errors);
+  }
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     astro: 'src/plugins/astro.ts',
     nuxt: 'src/plugins/nuxt.ts',
     angular: 'src/plugins/angular.ts',
+    sveltekit: 'src/plugins/sveltekit.ts',
     widget: 'src/widget/core.ts',
     react: 'src/widget/react.tsx',
     vue: 'src/widget/vue.ts',

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -67,6 +67,7 @@ export default defineConfig({
 						{ label: 'Next.js', slug: 'frameworks/nextjs' },
 						{ label: 'Vite', slug: 'frameworks/vite' },
 						{ label: 'Nuxt', slug: 'frameworks/nuxt' },
+						{ label: 'SvelteKit', slug: 'frameworks/sveltekit' },
 						{ label: 'Angular', slug: 'frameworks/angular' },
 						{ label: 'Webpack', slug: 'frameworks/webpack' },
 						{ label: 'Vanilla JS / Static HTML', slug: 'frameworks/vanilla' },

--- a/website/src/content/docs/frameworks/sveltekit.mdx
+++ b/website/src/content/docs/frameworks/sveltekit.mdx
@@ -1,0 +1,70 @@
+---
+title: SvelteKit
+description: Use aeo.js with SvelteKit.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+## Setup
+
+<Steps>
+1. Install the package:
+   ```bash
+   npm install aeo.js
+   ```
+
+2. Add a post-build step to your `package.json`:
+   ```json
+   {
+     "scripts": {
+       "postbuild": "node -e \"import('aeo.js/sveltekit').then(m => m.postBuild({ title: 'My Site', url: 'https://mysite.com' }))\""
+     }
+   }
+   ```
+
+3. Build your app:
+   ```bash
+   npm run build
+   ```
+</Steps>
+
+## How it works
+
+The SvelteKit plugin:
+
+- Detects the build output: `build/` for `adapter-static`, or `.svelte-kit/output` for other adapters
+- Scans prerendered HTML pages for titles, descriptions, and full text content
+- Scans `src/routes` for `+page.svelte` (and mdsvex `+page.md`/`+page.svx`) routes — route groups like `(marketing)` are transparent, dynamic segments like `[slug]` are skipped
+- Generates all AEO files (robots.txt, llms.txt, sitemap.xml, ai-index.json, …) into the output directory
+- Injects the Human/AI widget into every prerendered page
+
+<Aside type="tip">
+For the best results, prerender as much as possible (`export const prerender = true` in your root `+layout.ts`). aeo.js extracts content from prerendered HTML — server-rendered-only routes are still listed from source scanning, but without page content.
+</Aside>
+
+## Programmatic usage
+
+Generate AEO files from source routes without a build — files land in `static/` so any adapter ships them:
+
+```ts
+import { generate } from 'aeo.js/sveltekit';
+
+await generate({ title: 'My Site', url: 'https://mysite.com' });
+```
+
+## Configuration
+
+Pass any [AeoConfig](/reference/configuration/) options to `postBuild` or `generate`:
+
+```ts
+import { postBuild } from 'aeo.js/sveltekit';
+
+await postBuild({
+  title: 'My Site',
+  url: 'https://mysite.com',
+  description: 'A site optimized for AI discovery',
+  widget: { enabled: true, position: 'bottom-right' },
+  // Skip widget injection into prerendered HTML:
+  // injectWidget: false,
+});
+```


### PR DESCRIPTION
Adds the SvelteKit plugin — the types and detection already anticipated it (`FrameworkType` includes `sveltekit`, tsup externals include `@sveltejs/kit`); this ships the actual integration.

## What

- **`aeo.js/sveltekit`** new entry point following the Angular plugin pattern:
  - `postBuild()` — detects the output dir (`build/` for adapter-static, `.svelte-kit/output` + prerendered pages for other adapters), scans prerendered HTML for content, generates all AEO files alongside the build, and injects the Human/AI widget into every prerendered page (idempotent, opt-out via `injectWidget: false`).
  - `generate()` — source-only mode scanning `src/routes` (`+page.svelte`/`+page.md`/`+page.svx`; route groups `(name)` transparent, dynamic `[slug]` segments skipped), writing into `static/`.
  - `getWidgetScript()` — same surface as the Angular plugin.
- tsup entry + `exports` map wiring
- Docs: `frameworks/sveltekit` guide + sidebar entry + README quick start & table row

## Verification

- `tsc --noEmit` clean, build succeeds with the new entry
- 187 tests pass (7 new, real-filesystem fixtures: route scanning incl. groups/dynamic segments, adapter-static postBuild output, widget injection idempotency, non-static adapter fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)