### PR TITLE
feat: Remix / React Router 7 integration (aeo.js/remix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ export default defineNuxtConfig({
 });
 ```
 
+### Remix
+
+```json
+{
+  "scripts": {
+    "postbuild": "node -e \"import('aeo.js/remix').then(m => m.postBuild({ title: 'My Site', url: 'https://mysite.com' }))\""
+  }
+}
+```
+
 ### Angular
 
 ```json
@@ -147,6 +157,7 @@ npx aeo.js check
 | Next.js | `aeo.js/next` |
 | Vite | `aeo.js/vite` |
 | Nuxt | `aeo.js/nuxt` |
+| Remix | `aeo.js/remix` |
 | Angular | `aeo.js/angular` |
 | Webpack | `aeo.js/webpack` |
 | CLI | `npx aeo.js generate` |

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
       "import": "./dist/angular.mjs",
       "require": "./dist/angular.js"
     },
+    "./remix": {
+      "types": "./dist/remix.d.ts",
+      "import": "./dist/remix.mjs",
+      "require": "./dist/remix.js"
+    },
     "./react": {
       "types": "./dist/react.d.ts",
       "import": "./dist/react.mjs",

--- a/src/plugins/remix.test.ts
+++ b/src/plugins/remix.test.ts
@@ -95,6 +95,23 @@ describe('postBuild', () => {
 
     expect(existsSync(join(projectDir, 'public', 'robots.txt'))).toBe(true);
   });
+
+  it('config.pages entries override auto-scanned pages for the same pathname', async () => {
+    const client = join(projectDir, 'build', 'client');
+    mkdirSync(join(client, 'about'), { recursive: true });
+    writeFileSync(join(client, 'about', 'index.html'), HTML('About'));
+
+    await postBuild({
+      title: 'My Site',
+      url: 'https://mysite.com',
+      widget: { enabled: false },
+      pages: [{ pathname: '/about', title: 'About (Override)', description: 'Custom description.' }],
+    });
+
+    const llms = readFileSync(join(client, 'llms.txt'), 'utf-8');
+    expect(llms).toContain('About (Override)');
+    expect(llms).not.toContain('Description for About');
+  });
 });
 
 describe('getWidgetScript', () => {

--- a/src/plugins/remix.test.ts
+++ b/src/plugins/remix.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { postBuild, generate, getWidgetScript, remixRouteToPathname } from './remix';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let projectDir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  projectDir = mkdtempSync(join(tmpdir(), 'aeo-remix-'));
+  process.chdir(projectDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe('remixRouteToPathname', () => {
+  it('maps flat-route ids to pathnames', () => {
+    expect(remixRouteToPathname('_index')).toBe('/');
+    expect(remixRouteToPathname('about')).toBe('/about');
+    expect(remixRouteToPathname('blog._index')).toBe('/blog');
+    expect(remixRouteToPathname('docs.getting-started')).toBe('/docs/getting-started');
+  });
+
+  it('returns null for dynamic segments', () => {
+    expect(remixRouteToPathname('blog.$slug')).toBeNull();
+    expect(remixRouteToPathname('files.$')).toBeNull();
+  });
+
+  it('omits pathless layouts and optional segments', () => {
+    expect(remixRouteToPathname('_marketing.pricing')).toBe('/pricing');
+    expect(remixRouteToPathname('($lang).about')).toBe('/about');
+  });
+
+  it('strips the trailing underscore that opts out of layout nesting', () => {
+    expect(remixRouteToPathname('blog_.stats')).toBe('/blog/stats');
+  });
+});
+
+describe('generate (source routes)', () => {
+  it('discovers flat-file and folder routes, skipping dynamic ones', async () => {
+    const routes = join(projectDir, 'app', 'routes');
+    mkdirSync(join(routes, 'contact'), { recursive: true });
+    writeFileSync(join(routes, '_index.tsx'), 'export default function Home() {}');
+    writeFileSync(join(routes, 'about.tsx'), 'export default function About() {}');
+    writeFileSync(join(routes, 'blog.$slug.tsx'), 'export default function Post() {}');
+    writeFileSync(join(routes, 'contact', 'route.tsx'), 'export default function Contact() {}');
+
+    await generate({ title: 'My Site', url: 'https://mysite.com', widget: { enabled: false } });
+
+    const llms = readFileSync(join(projectDir, 'public', 'llms.txt'), 'utf-8');
+    expect(llms).toContain('/about');
+    expect(llms).toContain('/contact');
+    expect(llms).not.toContain('$slug');
+  });
+});
+
+describe('postBuild', () => {
+  const HTML = (title: string) =>
+    `<!doctype html><html><head><title>${title}</title><meta name="description" content="Description for ${title} that is long enough."></head><body><h1>${title}</h1><p>Some real content about ${title}.</p></body></html>`;
+
+  it('generates AEO files into build/client and merges prerendered content', async () => {
+    const client = join(projectDir, 'build', 'client');
+    mkdirSync(join(client, 'about'), { recursive: true });
+    writeFileSync(join(client, 'index.html'), HTML('Home'));
+    writeFileSync(join(client, 'about', 'index.html'), HTML('About'));
+
+    const routes = join(projectDir, 'app', 'routes');
+    mkdirSync(routes, { recursive: true });
+    writeFileSync(join(routes, '_index.tsx'), 'export default function Home() {}');
+    writeFileSync(join(routes, 'pricing.tsx'), 'export default function Pricing() {}');
+
+    await postBuild({ title: 'My Site', url: 'https://mysite.com', widget: { enabled: false } });
+
+    expect(existsSync(join(client, 'robots.txt'))).toBe(true);
+    expect(existsSync(join(client, 'sitemap.xml'))).toBe(true);
+
+    const llms = readFileSync(join(client, 'llms.txt'), 'utf-8');
+    // prerendered pages contribute content, source-only routes still listed
+    expect(llms).toContain('/about');
+    expect(llms).toContain('/pricing');
+  });
+
+  it('falls back to public/ when there is no Vite build output', async () => {
+    mkdirSync(join(projectDir, 'public'), { recursive: true });
+    const routes = join(projectDir, 'app', 'routes');
+    mkdirSync(routes, { recursive: true });
+    writeFileSync(join(routes, '_index.tsx'), 'export default function Home() {}');
+
+    await postBuild({ title: 'My Site', url: 'https://mysite.com', widget: { enabled: false } });
+
+    expect(existsSync(join(projectDir, 'public', 'robots.txt'))).toBe(true);
+  });
+});
+
+describe('getWidgetScript', () => {
+  it('returns a module script with the widget config', () => {
+    const script = getWidgetScript({ title: 'My Site', url: 'https://mysite.com' });
+    expect(script).toContain("import('aeo.js/widget')");
+    expect(script).toContain('My Site');
+  });
+
+  it('returns empty string when the widget is disabled', () => {
+    expect(getWidgetScript({ widget: { enabled: false } })).toBe('');
+  });
+});

--- a/src/plugins/remix.ts
+++ b/src/plugins/remix.ts
@@ -265,16 +265,19 @@ export async function generate(config: AeoConfig = {}): Promise<void> {
 
   const pageMap = new Map<string, PageEntry>();
   for (const page of discoveredPages) {
+    pageMap.set(page.pathname, page);
+  }
+  for (const page of config.pages || []) {
+    pageMap.set(page.pathname, page);
+  }
+
+  for (const page of pageMap.values()) {
     if (page.pathname === '/' && !page.title && config.title) {
       page.title = config.title;
     }
     if (!page.description && config.description) {
       page.description = config.description;
     }
-    pageMap.set(page.pathname, page);
-  }
-  for (const page of config.pages || []) {
-    pageMap.set(page.pathname, page);
   }
 
   const resolvedConfig = resolveConfig({

--- a/src/plugins/remix.ts
+++ b/src/plugins/remix.ts
@@ -1,0 +1,272 @@
+import { generateAEOFiles } from '../core/generate';
+import { resolveConfig } from '../core/utils';
+import type { AeoConfig, PageEntry } from '../types';
+import { extractTextFromHtml, extractTitle, extractDescription } from '../core/html-extract';
+import { join } from 'path';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+
+const ROUTE_EXTENSIONS = /\.(tsx|jsx|ts|js|mdx?)$/;
+
+/**
+ * Convert a Remix v2 flat-route id (file name without extension) to a pathname.
+ * Returns null for routes that can't be enumerated statically (dynamic
+ * segments) or that aren't pages (resource-route conventions are kept —
+ * they still render at their path).
+ *
+ *   _index            → /
+ *   about             → /about
+ *   blog._index       → /blog
+ *   blog.$slug        → null (dynamic)
+ *   _marketing.pricing → /pricing (pathless layout segment omitted)
+ *   ($lang).about     → /about (optional segment omitted)
+ */
+export function remixRouteToPathname(routeId: string): string | null {
+  const segments: string[] = [];
+  for (const rawSegment of routeId.split('.')) {
+    // Trailing underscore opts out of layout nesting but keeps the path
+    const segment = rawSegment.endsWith('_') ? rawSegment.slice(0, -1) : rawSegment;
+    if (segment === '_index' || segment === 'index' || segment === 'route' || segment === '') continue;
+    if (segment.startsWith('_')) continue; // pathless layout
+    if (segment.startsWith('(') && segment.endsWith(')')) continue; // optional segment
+    if (segment.includes('$')) return null; // dynamic segment
+    // [escaped] segments map to their literal content
+    segments.push(segment.replace(/^\[(.*)\]$/, '$1'));
+  }
+  return '/' + segments.join('/');
+}
+
+/**
+ * Scan Remix routes from app/routes (flat files and route folders).
+ */
+function scanRemixRoutes(projectRoot: string): PageEntry[] {
+  const pages: PageEntry[] = [];
+  const routesDir = join(projectRoot, 'app', 'routes');
+  if (!existsSync(routesDir)) {
+    pages.push({ pathname: '/' });
+    return pages;
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(routesDir);
+  } catch {
+    return [{ pathname: '/' }];
+  }
+
+  for (const entry of entries) {
+    if (entry.startsWith('.')) continue;
+    const fullPath = join(routesDir, entry);
+    let stat;
+    try {
+      stat = statSync(fullPath);
+    } catch {
+      continue;
+    }
+
+    let routeId: string | null = null;
+    if (stat.isFile() && ROUTE_EXTENSIONS.test(entry)) {
+      routeId = entry.replace(ROUTE_EXTENSIONS, '');
+    } else if (stat.isDirectory()) {
+      // Folder route: app/routes/about/route.tsx
+      try {
+        const hasRouteFile = readdirSync(fullPath).some((f) => /^route\.(tsx|jsx|ts|js)$/.test(f));
+        if (hasRouteFile) routeId = entry;
+      } catch {
+        continue;
+      }
+    }
+    if (!routeId) continue;
+
+    const pathname = remixRouteToPathname(routeId);
+    if (pathname === null) continue;
+    if (pages.some((p) => p.pathname === pathname)) continue;
+
+    const segment = pathname.split('/').filter(Boolean).pop();
+    pages.push({
+      pathname,
+      title: segment ? segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' ') : undefined,
+    });
+  }
+
+  if (!pages.some((p) => p.pathname === '/')) {
+    pages.unshift({ pathname: '/' });
+  }
+
+  return pages;
+}
+
+/**
+ * Detect the Remix static assets directory.
+ * The Vite-based Remix / React Router 7 build writes to build/client;
+ * the classic compiler serves static files from public/.
+ */
+function detectRemixOutputDir(projectRoot: string): string {
+  const viteClient = join(projectRoot, 'build', 'client');
+  if (existsSync(viteClient)) return viteClient;
+  return join(projectRoot, 'public');
+}
+
+/** Scan a directory tree for prerendered HTML pages. */
+function scanHtmlOutput(outputDir: string): PageEntry[] {
+  const pages: PageEntry[] = [];
+  if (!existsSync(outputDir)) return pages;
+
+  function walk(dir: string, basePath: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory() && !entry.startsWith('.') && entry !== 'assets') {
+        walk(fullPath, `${basePath}/${entry}`);
+      } else if (entry.endsWith('.html') && entry !== '404.html' && entry !== '500.html') {
+        try {
+          const html = readFileSync(fullPath, 'utf-8');
+          const pathname = entry === 'index.html' ? basePath || '/' : `${basePath}/${entry.replace('.html', '')}`;
+          pages.push({
+            pathname,
+            title: extractTitle(html),
+            description: extractDescription(html),
+            content: extractTextFromHtml(html),
+          });
+        } catch {
+          /* skip */
+        }
+      }
+    }
+  }
+
+  walk(outputDir, '');
+  return pages;
+}
+
+/**
+ * Generate a widget script tag for Remix.
+ * Add it to your root route so the widget loads on every page:
+ *
+ *   <script type="module" dangerouslySetInnerHTML={{ __html: widgetScript }} />
+ */
+export function getWidgetScript(config: AeoConfig = {}): string {
+  const resolvedConfig = resolveConfig(config);
+  if (!resolvedConfig.widget.enabled) return '';
+
+  const widgetConfig = JSON.stringify({
+    title: resolvedConfig.title,
+    description: resolvedConfig.description,
+    url: resolvedConfig.url,
+    widget: resolvedConfig.widget,
+  });
+
+  return `<script type="module">
+import('aeo.js/widget').then(({ AeoWidget }) => {
+  try {
+    new AeoWidget({ config: ${widgetConfig} });
+  } catch (e) {
+    console.warn('[aeo.js] Widget initialization failed:', e);
+  }
+}).catch(() => {});
+</script>`;
+}
+
+/**
+ * Post-build function for Remix / React Router 7 projects.
+ * Scans the static assets directory (build/client for Vite builds,
+ * public/ for the classic compiler) plus any prerendered HTML, and
+ * generates AEO files alongside the static assets so they're served
+ * from the site root.
+ *
+ * Usage in package.json:
+ *   "postbuild": "node -e \"import('aeo.js/remix').then(m => m.postBuild({ title: 'My Site', url: 'https://mysite.com' }))\""
+ */
+export async function postBuild(config: AeoConfig = {}): Promise<void> {
+  const projectRoot = process.cwd();
+  const outputDir = config.outDir || detectRemixOutputDir(projectRoot);
+
+  console.log(`[aeo.js] Scanning Remix build output: ${outputDir}`);
+
+  // Prerendered HTML (react-router's prerender option) lands in build/client
+  const buildPages = scanHtmlOutput(outputDir);
+  if (buildPages.length > 0) {
+    console.log(`[aeo.js] Discovered ${buildPages.length} prerendered pages`);
+  }
+
+  const sourcePages = scanRemixRoutes(projectRoot);
+
+  // Merge: prerendered output (with content) takes priority over source routes
+  const allPages = [...buildPages, ...sourcePages, ...(config.pages || [])];
+  const pageMap = new Map<string, PageEntry>();
+  for (const page of allPages) {
+    const existing = pageMap.get(page.pathname);
+    if (!existing || (page.content && !existing.content)) {
+      pageMap.set(page.pathname, page);
+    }
+  }
+
+  for (const page of pageMap.values()) {
+    if (page.pathname === '/' && !page.title && config.title) {
+      page.title = config.title;
+    }
+    if (!page.description && config.description) {
+      page.description = config.description;
+    }
+  }
+
+  const resolvedConfig = resolveConfig({
+    ...config,
+    outDir: outputDir,
+    pages: Array.from(pageMap.values()),
+  });
+
+  const result = await generateAEOFiles(resolvedConfig);
+  if (result.files.length > 0) {
+    console.log(`[aeo.js] Generated ${result.files.length} files`);
+  }
+  if (result.errors.length > 0) {
+    console.error('[aeo.js] Errors:', result.errors);
+  }
+}
+
+/**
+ * Generate AEO files for Remix from source routes only (no build output).
+ * Writes into public/ so the classic compiler and dev server ship them.
+ */
+export async function generate(config: AeoConfig = {}): Promise<void> {
+  const projectRoot = process.cwd();
+  const discoveredPages = scanRemixRoutes(projectRoot);
+
+  if (discoveredPages.length > 0) {
+    console.log(`[aeo.js] Discovered ${discoveredPages.length} routes from Remix source`);
+  }
+
+  for (const page of discoveredPages) {
+    if (page.pathname === '/' && !page.title && config.title) {
+      page.title = config.title;
+    }
+    if (!page.description && config.description) {
+      page.description = config.description;
+    }
+  }
+
+  const resolvedConfig = resolveConfig({
+    ...config,
+    outDir: config.outDir || 'public',
+    pages: [...(config.pages || []), ...discoveredPages],
+  });
+
+  const result = await generateAEOFiles(resolvedConfig);
+  if (result.files.length > 0) {
+    console.log(`[aeo.js] Generated ${result.files.length} files`);
+  }
+  if (result.errors.length > 0) {
+    console.error('[aeo.js] Errors:', result.errors);
+  }
+}

--- a/src/plugins/remix.ts
+++ b/src/plugins/remix.ts
@@ -167,7 +167,10 @@ export function getWidgetScript(config: AeoConfig = {}): string {
     description: resolvedConfig.description,
     url: resolvedConfig.url,
     widget: resolvedConfig.widget,
-  });
+  })
+    .replace(/&/g, '\\u0026')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
 
   return `<script type="module">
 import('aeo.js/widget').then(({ AeoWidget }) => {
@@ -255,6 +258,7 @@ export async function generate(config: AeoConfig = {}): Promise<void> {
     console.log(`[aeo.js] Discovered ${discoveredPages.length} routes from Remix source`);
   }
 
+  const pageMap = new Map<string, PageEntry>();
   for (const page of discoveredPages) {
     if (page.pathname === '/' && !page.title && config.title) {
       page.title = config.title;
@@ -262,12 +266,16 @@ export async function generate(config: AeoConfig = {}): Promise<void> {
     if (!page.description && config.description) {
       page.description = config.description;
     }
+    pageMap.set(page.pathname, page);
+  }
+  for (const page of config.pages || []) {
+    pageMap.set(page.pathname, page);
   }
 
   const resolvedConfig = resolveConfig({
     ...config,
     outDir: config.outDir || 'public',
-    pages: [...(config.pages || []), ...discoveredPages],
+    pages: Array.from(pageMap.values()),
   });
 
   const result = await generateAEOFiles(resolvedConfig);

--- a/src/plugins/remix.ts
+++ b/src/plugins/remix.ts
@@ -22,10 +22,15 @@ const ROUTE_EXTENSIONS = /\.(tsx|jsx|ts|js|mdx?)$/;
  */
 export function remixRouteToPathname(routeId: string): string | null {
   const segments: string[] = [];
-  for (const rawSegment of routeId.split('.')) {
+  const rawParts = routeId.split('.');
+  for (let i = 0; i < rawParts.length; i++) {
+    const rawSegment = rawParts[i];
     // Trailing underscore opts out of layout nesting but keeps the path
     const segment = rawSegment.endsWith('_') ? rawSegment.slice(0, -1) : rawSegment;
-    if (segment === '_index' || segment === 'index' || segment === 'route' || segment === '') continue;
+    if (segment === '_index' || segment === 'index' || segment === '') continue;
+    // 'route' is only a folder-route disambiguation suffix when it's the last part of
+    // a multi-segment id (e.g. blog.route.tsx → /blog). A standalone route.tsx → /route.
+    if (segment === 'route' && i === rawParts.length - 1 && i > 0) continue;
     if (segment.startsWith('_')) continue; // pathless layout
     if (segment.startsWith('(') && segment.endsWith(')')) continue; // optional segment
     if (segment.includes('$')) return null; // dynamic segment

--- a/src/plugins/remix.ts
+++ b/src/plugins/remix.ts
@@ -151,9 +151,12 @@ function scanHtmlOutput(outputDir: string): PageEntry[] {
 
 /**
  * Generate a widget script tag for Remix.
+ * Returns a complete `<script type="module">…</script>` string.
  * Add it to your root route so the widget loads on every page:
  *
- *   <script type="module" dangerouslySetInnerHTML={{ __html: widgetScript }} />
+ *   const widgetScript = getWidgetScript(config);
+ *   // …
+ *   <div dangerouslySetInnerHTML={{ __html: widgetScript }} />
  */
 export function getWidgetScript(config: AeoConfig = {}): string {
   const resolvedConfig = resolveConfig(config);
@@ -201,14 +204,19 @@ export async function postBuild(config: AeoConfig = {}): Promise<void> {
 
   const sourcePages = scanRemixRoutes(projectRoot);
 
-  // Merge: prerendered output (with content) takes priority over source routes
-  const allPages = [...buildPages, ...sourcePages, ...(config.pages || [])];
+  // Merge: prerendered output (with content) takes priority over source routes;
+  // config.pages always wins last, giving users unconditional override power.
+  const autoPages = [...buildPages, ...sourcePages];
   const pageMap = new Map<string, PageEntry>();
-  for (const page of allPages) {
+  for (const page of autoPages) {
     const existing = pageMap.get(page.pathname);
     if (!existing || (page.content && !existing.content)) {
       pageMap.set(page.pathname, page);
     }
+  }
+  // config.pages entries unconditionally overwrite auto-scanned entries
+  for (const page of config.pages || []) {
+    pageMap.set(page.pathname, page);
   }
 
   for (const page of pageMap.values()) {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     astro: 'src/plugins/astro.ts',
     nuxt: 'src/plugins/nuxt.ts',
     angular: 'src/plugins/angular.ts',
+    remix: 'src/plugins/remix.ts',
     widget: 'src/widget/core.ts',
     react: 'src/widget/react.tsx',
     vue: 'src/widget/vue.ts',

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -67,6 +67,7 @@ export default defineConfig({
 						{ label: 'Next.js', slug: 'frameworks/nextjs' },
 						{ label: 'Vite', slug: 'frameworks/vite' },
 						{ label: 'Nuxt', slug: 'frameworks/nuxt' },
+						{ label: 'Remix', slug: 'frameworks/remix' },
 						{ label: 'Angular', slug: 'frameworks/angular' },
 						{ label: 'Webpack', slug: 'frameworks/webpack' },
 						{ label: 'Vanilla JS / Static HTML', slug: 'frameworks/vanilla' },

--- a/website/src/content/docs/frameworks/remix.mdx
+++ b/website/src/content/docs/frameworks/remix.mdx
@@ -1,0 +1,84 @@
+---
+title: Remix
+description: Use aeo.js with Remix and React Router 7.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+## Setup
+
+<Steps>
+1. Install the package:
+   ```bash
+   npm install aeo.js
+   ```
+
+2. Add a post-build step to your `package.json`:
+   ```json
+   {
+     "scripts": {
+       "postbuild": "node -e \"import('aeo.js/remix').then(m => m.postBuild({ title: 'My Site', url: 'https://mysite.com' }))\""
+     }
+   }
+   ```
+
+3. Build your app:
+   ```bash
+   npm run build
+   ```
+</Steps>
+
+## How it works
+
+The Remix plugin:
+
+- Detects the static assets directory: `build/client` for Vite-based Remix / React Router 7, `public/` for the classic compiler
+- Scans `app/routes` flat-file routes (`_index.tsx`, `about.tsx`, `blog._index.tsx`, folder routes with `route.tsx`) — pathless layouts (`_marketing.`) and optional segments (`($lang).`) are resolved, dynamic segments (`$slug`) are skipped
+- Scans prerendered HTML (React Router's `prerender` option) for titles, descriptions, and full text content
+- Generates all AEO files (robots.txt, llms.txt, sitemap.xml, ai-index.json, …) into the static assets directory so they're served from the site root
+
+<Aside type="tip">
+Enable [prerendering](https://reactrouter.com/how-to/pre-rendering) for your static routes — aeo.js extracts full page content from prerendered HTML. Routes that only render on the server are still listed from source scanning, but without page content.
+</Aside>
+
+## Widget
+
+Remix renders HTML on the server, so add the widget script to your root route once:
+
+```tsx
+// app/root.tsx
+import { getWidgetScript } from 'aeo.js/remix';
+
+const widgetScript = getWidgetScript({
+  title: 'My Site',
+  url: 'https://mysite.com',
+});
+
+// In your Layout component, before </body>:
+<div dangerouslySetInnerHTML={{ __html: widgetScript }} />
+```
+
+## Programmatic usage
+
+Generate AEO files from source routes without a build — files land in `public/`:
+
+```ts
+import { generate } from 'aeo.js/remix';
+
+await generate({ title: 'My Site', url: 'https://mysite.com' });
+```
+
+## Configuration
+
+Pass any [AeoConfig](/reference/configuration/) options to `postBuild` or `generate`:
+
+```ts
+import { postBuild } from 'aeo.js/remix';
+
+await postBuild({
+  title: 'My Site',
+  url: 'https://mysite.com',
+  description: 'A site optimized for AI discovery',
+  schema: { organization: { name: 'My Company' } },
+});
+```


### PR DESCRIPTION
Adds the Remix plugin — `FrameworkType` already listed `remix`; this ships the integration.

## What

- **`aeo.js/remix`** new entry point following the postBuild pattern:
  - `postBuild()` — detects the static assets dir (`build/client` for Vite-based Remix/RR7, `public/` for the classic compiler), scans `app/routes` flat-file + folder routes, merges content from prerendered HTML (React Router's `prerender` option), generates all AEO files into the assets dir.
  - Route-id parsing handles `_index`, dot-delimited nesting, pathless layouts (`_marketing.`), optional segments (`().`), trailing-underscore layout opt-out, and skips dynamic segments (`$slug`) — exported as `remixRouteToPathname()` and unit-tested.
  - `generate()` — source-only mode writing into `public/`.
  - `getWidgetScript()` — root-route widget snippet (Remix has no static index.html to inject into).
- tsup entry + `exports` map wiring
- Docs: `frameworks/remix` guide + sidebar entry + README quick start & table row

## Verification

- `tsc --noEmit` clean, build succeeds
- 189 tests pass (9 new: route-id mapping incl. edge cases, source scanning, build/client + public/ fallback postBuild, widget script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)