### PR TITLE
feat: MCP server — let agents audit sites and generate AEO files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ Commands:
   init              Create an aeo.config.ts configuration file
   check [url]       GEO readiness score (0-100) — local setup, or any live site
   report [url]      Full AEO/GEO report with citability scores and platform hints
+  mcp               Run an MCP server (stdio) exposing audit and generation tools
 
 Options:
   --out <dir>       Output directory (default: auto-detected)
@@ -401,6 +402,11 @@ async function main(): Promise<void> {
         cmdReport(flags);
       }
       break;
+    case 'mcp': {
+      const { runMcpStdio } = await import('./core/mcp-server');
+      runMcpStdio();
+      break;
+    }
     default:
       console.error(`Unknown command: ${command}`);
       console.log(HELP);

--- a/src/core/mcp-server.test.ts
+++ b/src/core/mcp-server.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { handleMcpRequest } from './mcp-server';
+
+function req(method: string, params?: Record<string, unknown>, id: number | undefined = 1) {
+  return { jsonrpc: '2.0' as const, id, method, params };
+}
+
+describe('handleMcpRequest', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('responds to initialize with server info and tools capability', async () => {
+    const res = await handleMcpRequest(req('initialize', { protocolVersion: '2025-03-26' }));
+    expect(res?.result).toMatchObject({
+      protocolVersion: '2025-03-26',
+      capabilities: { tools: {} },
+      serverInfo: { name: 'aeo.js' },
+    });
+  });
+
+  it('responds to ping', async () => {
+    const res = await handleMcpRequest(req('ping'));
+    expect(res?.result).toEqual({});
+  });
+
+  it('lists the three tools with input schemas', async () => {
+    const res = await handleMcpRequest(req('tools/list'));
+    const tools = (res?.result as any).tools;
+    expect(tools.map((t: any) => t.name)).toEqual(['audit_url', 'score_citability', 'generate_aeo_files']);
+    for (const tool of tools) {
+      expect(tool.inputSchema.type).toBe('object');
+      expect(tool.description.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('returns method-not-found for unknown requests with an id', async () => {
+    const res = await handleMcpRequest(req('resources/list'));
+    expect(res?.error?.code).toBe(-32601);
+  });
+
+  it('ignores notifications (no id)', async () => {
+    const res = await handleMcpRequest({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    expect(res).toBeNull();
+  });
+
+  it('scores citability via tools/call', async () => {
+    const content = [
+      'aeo.js generates llms.txt files for over 7 frameworks as of 2026.',
+      'The audit produces a score from 0 to 100 across five categories.',
+    ].join('\n\n');
+    const res = await handleMcpRequest(req('tools/call', { name: 'score_citability', arguments: { content } }));
+    const result = res?.result as any;
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toMatch(/Score: \d+\/100/);
+  });
+
+  it('returns a tool error for empty citability content', async () => {
+    const res = await handleMcpRequest(req('tools/call', { name: 'score_citability', arguments: { content: '' } }));
+    expect((res?.result as any).isError).toBe(true);
+  });
+
+  it('returns invalid-params error for unknown tools', async () => {
+    const res = await handleMcpRequest(req('tools/call', { name: 'nope', arguments: {} }));
+    expect(res?.error?.code).toBe(-32602);
+  });
+
+  it('audits a URL via tools/call with mocked fetch', async () => {
+    const html =
+      '<html><head><title>A Test Page Title</title></head><body><h1>Hi</h1><p>Welcome to the test page with some content.</p></body></html>';
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => ({
+      ok: url === 'https://a.com' || url === 'https://a.com/',
+      status: 200,
+      headers: new Headers({ 'content-type': 'text/html' }),
+      text: async () => html,
+    })));
+
+    const res = await handleMcpRequest(req('tools/call', { name: 'audit_url', arguments: { url: 'a.com' } }));
+    const result = res?.result as any;
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('GEO Readiness Score');
+  });
+
+  it('returns a tool error for invalid audit targets', async () => {
+    const res = await handleMcpRequest(req('tools/call', { name: 'audit_url', arguments: { url: 'not a url' } }));
+    expect((res?.result as any).isError).toBe(true);
+  });
+});

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -239,8 +239,10 @@ export function runMcpStdio(): void {
           if (response) process.stdout.write(JSON.stringify(response) + '\n');
         })
         .catch((err: NodeJS.ErrnoException) => {
-          if (err.code === 'EPIPE') return; // client disconnected — swallow silently
-          throw err;
+          // Swallow all stdout write errors — EPIPE means the client disconnected,
+          // EBADF/ENOTSOCK can occur on unusual stdio setups. Log to stderr so
+          // the error is visible without crashing the long-running server process.
+          process.stderr.write(`[aeo.js mcp] stdout write error: ${err.code ?? err.message}\n`);
         });
     }
   });

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -12,19 +12,19 @@ import { VERSION } from '../index';
  * ping — as plain JSON-RPC, so no SDK dependency is required.
  */
 
-interface JsonRpcRequest {
+type JsonRpcRequest = {
   jsonrpc: '2.0';
   id?: number | string | null;
   method: string;
   params?: Record<string, unknown>;
-}
+};
 
-interface JsonRpcResponse {
+type JsonRpcResponse = {
   jsonrpc: '2.0';
   id: number | string | null;
   result?: unknown;
   error?: { code: number; message: string };
-}
+};
 
 const TOOLS = [
   {

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -3,6 +3,7 @@ import { buildRemoteReport, formatRemoteReport } from './remote-audit';
 import { scorePageCitability, formatPageCitability } from './citability';
 import { generateAEOFiles } from './generate';
 import { resolveConfig } from './utils';
+import { resolve, isAbsolute } from 'path';
 import { VERSION } from '../index';
 
 /**
@@ -133,11 +134,24 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<un
       if (typeof args.title !== 'string' || typeof args.url !== 'string') {
         return textResult('Both "title" and "url" arguments are required.', true);
       }
+      const canonicalUrl = normalizeUrl(args.url);
+      if (!canonicalUrl) {
+        return textResult(`"${args.url}" is not a valid URL or domain.`, true);
+      }
+      let safeOutDir: string | undefined;
+      if (typeof args.outDir === 'string') {
+        const cwd = process.cwd();
+        const resolved = isAbsolute(args.outDir) ? args.outDir : resolve(cwd, args.outDir);
+        if (!resolved.startsWith(cwd + '/') && resolved !== cwd) {
+          return textResult('outDir must be inside the current working directory.', true);
+        }
+        safeOutDir = resolved;
+      }
       const config = resolveConfig({
         title: args.title,
-        url: args.url,
+        url: canonicalUrl,
         description: typeof args.description === 'string' ? args.description : undefined,
-        outDir: typeof args.outDir === 'string' ? args.outDir : undefined,
+        outDir: safeOutDir,
       });
       const result = await generateAEOFiles(config);
       const lines = [

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -170,7 +170,7 @@ export async function handleMcpRequest(request: JsonRpcRequest): Promise<JsonRpc
           jsonrpc: '2.0',
           id,
           result: {
-            protocolVersion: (request.params?.protocolVersion as string) || '2024-11-05',
+            protocolVersion: '2025-03-26',
             capabilities: { tools: {} },
             serverInfo: { name: 'aeo.js', version: VERSION },
           },
@@ -234,9 +234,14 @@ export function runMcpStdio(): void {
         continue;
       }
 
-      handleMcpRequest(request).then((response) => {
-        if (response) process.stdout.write(JSON.stringify(response) + '\n');
-      });
+      handleMcpRequest(request)
+        .then((response) => {
+          if (response) process.stdout.write(JSON.stringify(response) + '\n');
+        })
+        .catch((err: NodeJS.ErrnoException) => {
+          if (err.code === 'EPIPE') return; // client disconnected — swallow silently
+          throw err;
+        });
     }
   });
 

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -1,0 +1,244 @@
+import { discover, crawlPages } from './remote-crawl';
+import { buildRemoteReport, formatRemoteReport } from './remote-audit';
+import { scorePageCitability, formatPageCitability } from './citability';
+import { generateAEOFiles } from './generate';
+import { resolveConfig } from './utils';
+import { VERSION } from '../index';
+
+/**
+ * Minimal MCP (Model Context Protocol) server over stdio.
+ * Implements the subset agents need — initialize, tools/list, tools/call,
+ * ping — as plain JSON-RPC, so no SDK dependency is required.
+ */
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id?: number | string | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+const TOOLS = [
+  {
+    name: 'audit_url',
+    description:
+      'Audit any live website for AI answer-engine readiness (AEO/GEO). Crawls the site (robots.txt, llms.txt, sitemap, homepage + up to 10 inner pages) and returns a 0-100 GEO readiness score across 5 categories, an AI crawler access matrix (GPTBot, ClaudeBot, PerplexityBot, ...), content citability scores, and the top recommended fixes.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'The site URL or bare domain to audit, e.g. "example.com"' },
+        json: {
+          type: 'boolean',
+          description: 'Return the full structured report as JSON instead of formatted text. Default false.',
+        },
+      },
+      required: ['url'],
+    },
+  },
+  {
+    name: 'score_citability',
+    description:
+      'Score a piece of content (markdown or plain text) for AI citability: how likely AI answer engines are to extract and cite it. Returns a 0-100 score across 4 dimensions (answer clarity, self-containment, statistical density, structure) with concrete improvement hints. Use while drafting or editing content.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        content: { type: 'string', description: 'The content to score (markdown or plain text)' },
+        title: { type: 'string', description: 'Optional page title' },
+        description: { type: 'string', description: 'Optional meta description' },
+      },
+      required: ['content'],
+    },
+  },
+  {
+    name: 'generate_aeo_files',
+    description:
+      'Generate AEO files (robots.txt with AI crawler directives, llms.txt, llms-full.txt, sitemap.xml, ai-index.json, schema.json, per-page markdown) into a directory of the current project. Run from the project root after a build.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'Site title' },
+        url: { type: 'string', description: 'Canonical site URL, e.g. "https://mysite.com"' },
+        description: { type: 'string', description: 'Site description' },
+        outDir: { type: 'string', description: 'Output directory (default: auto-detected build output)' },
+      },
+      required: ['title', 'url'],
+    },
+  },
+];
+
+function normalizeUrl(input: string): string | null {
+  let candidate = input.trim();
+  if (!/^https?:\/\//i.test(candidate)) {
+    if (!/^[a-z0-9-]+(\.[a-z0-9-]+)+(:\d+)?(\/.*)?$/i.test(candidate)) return null;
+    candidate = 'https://' + candidate;
+  }
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+function textResult(text: string, isError = false) {
+  return { content: [{ type: 'text', text }], isError };
+}
+
+async function callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+  switch (name) {
+    case 'audit_url': {
+      const target = typeof args.url === 'string' ? normalizeUrl(args.url) : null;
+      if (!target) return textResult(`"${args.url}" is not a valid URL or domain.`, true);
+
+      const discovery = await discover(target);
+      if (!discovery.homepage) {
+        return textResult(`Could not reach ${target} — the site may be down or blocking requests.`, true);
+      }
+      const pages = await crawlPages(discovery, target);
+      const report = buildRemoteReport(target, discovery, pages);
+
+      if (args.json) {
+        const slim = {
+          ...report,
+          discovery: { ...report.discovery, homepage: { url: target } },
+          pages: report.pages.map(({ html: _html, ...page }) => page),
+        };
+        return textResult(JSON.stringify(slim, null, 2));
+      }
+      return textResult(formatRemoteReport(report));
+    }
+
+    case 'score_citability': {
+      if (typeof args.content !== 'string' || args.content.length === 0) {
+        return textResult('The "content" argument is required and must be a non-empty string.', true);
+      }
+      const result = scorePageCitability({
+        pathname: '/',
+        title: typeof args.title === 'string' ? args.title : undefined,
+        description: typeof args.description === 'string' ? args.description : undefined,
+        content: args.content,
+      });
+      return textResult(formatPageCitability(result));
+    }
+
+    case 'generate_aeo_files': {
+      if (typeof args.title !== 'string' || typeof args.url !== 'string') {
+        return textResult('Both "title" and "url" arguments are required.', true);
+      }
+      const config = resolveConfig({
+        title: args.title,
+        url: args.url,
+        description: typeof args.description === 'string' ? args.description : undefined,
+        outDir: typeof args.outDir === 'string' ? args.outDir : undefined,
+      });
+      const result = await generateAEOFiles(config);
+      const lines = [
+        `Generated ${result.files.length} file(s) in ${config.outDir}:`,
+        ...result.files.map((f) => `  - ${f}`),
+      ];
+      if (result.errors.length > 0) {
+        lines.push('', `Errors:`, ...result.errors.map((e) => `  - ${e}`));
+      }
+      return textResult(lines.join('\n'), result.errors.length > 0);
+    }
+
+    default:
+      throw Object.assign(new Error(`Unknown tool: ${name}`), { code: -32602 });
+  }
+}
+
+/**
+ * Handle a single JSON-RPC request. Returns null for notifications
+ * (requests without an id), which expect no response.
+ */
+export async function handleMcpRequest(request: JsonRpcRequest): Promise<JsonRpcResponse | null> {
+  const id = request.id ?? null;
+  const isNotification = request.id === undefined;
+
+  try {
+    switch (request.method) {
+      case 'initialize':
+        return {
+          jsonrpc: '2.0',
+          id,
+          result: {
+            protocolVersion: (request.params?.protocolVersion as string) || '2024-11-05',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'aeo.js', version: VERSION },
+          },
+        };
+
+      case 'ping':
+        return { jsonrpc: '2.0', id, result: {} };
+
+      case 'tools/list':
+        return { jsonrpc: '2.0', id, result: { tools: TOOLS } };
+
+      case 'tools/call': {
+        const name = request.params?.name as string;
+        const args = (request.params?.arguments as Record<string, unknown>) ?? {};
+        const result = await callTool(name, args);
+        return { jsonrpc: '2.0', id, result };
+      }
+
+      default:
+        if (isNotification) return null; // notifications/initialized etc.
+        return {
+          jsonrpc: '2.0',
+          id,
+          error: { code: -32601, message: `Method not found: ${request.method}` },
+        };
+    }
+  } catch (error: any) {
+    if (isNotification) return null;
+    return {
+      jsonrpc: '2.0',
+      id,
+      error: { code: typeof error?.code === 'number' ? error.code : -32603, message: error?.message ?? 'Internal error' },
+    };
+  }
+}
+
+/**
+ * Run the MCP server on stdio: newline-delimited JSON-RPC on stdin/stdout.
+ * Logs go to stderr so they never corrupt the protocol stream.
+ */
+export function runMcpStdio(): void {
+  console.error(`[aeo.js] MCP server v${VERSION} listening on stdio`);
+
+  let buffer = '';
+  process.stdin.setEncoding('utf-8');
+  process.stdin.on('data', (chunk: string) => {
+    buffer += chunk;
+    let newline: number;
+    while ((newline = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, newline).trim();
+      buffer = buffer.slice(newline + 1);
+      if (!line) continue;
+
+      let request: JsonRpcRequest;
+      try {
+        request = JSON.parse(line);
+      } catch {
+        process.stdout.write(
+          JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }) + '\n'
+        );
+        continue;
+      }
+
+      handleMcpRequest(request).then((response) => {
+        if (response) process.stdout.write(JSON.stringify(response) + '\n');
+      });
+    }
+  });
+
+  process.stdin.on('end', () => process.exit(0));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { AeoConfig } from './types';
 
-export const VERSION = '0.0.13';
+export const VERSION = '0.0.14';
 
 export function defineConfig(config: AeoConfig): AeoConfig {
   return config;

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -81,6 +81,7 @@ export default defineConfig({
 						{ label: 'Schema & Open Graph', slug: 'features/schema-og' },
 						{ label: 'JSON-LD Recipes', slug: 'features/json-ld' },
 						{ label: 'Audit & Citability', slug: 'features/audit' },
+						{ label: 'MCP Server', slug: 'features/mcp' },
 					],
 				},
 				{

--- a/website/src/content/docs/features/mcp.mdx
+++ b/website/src/content/docs/features/mcp.mdx
@@ -1,0 +1,53 @@
+---
+title: MCP Server
+description: Let AI agents audit sites and generate AEO files via the Model Context Protocol.
+---
+
+aeo.js ships an [MCP](https://modelcontextprotocol.io) server so AI agents — Claude Code, Claude Desktop, Cursor, or anything MCP-compatible — can audit sites and generate AEO files conversationally.
+
+## Setup
+
+No install needed. Add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "aeo": {
+      "command": "npx",
+      "args": ["-y", "aeo.js", "mcp"]
+    }
+  }
+}
+```
+
+For Claude Code:
+
+```bash
+claude mcp add aeo -- npx -y aeo.js mcp
+```
+
+## Tools
+
+### `audit_url`
+
+Audit any live site for AI answer-engine readiness. Crawls the AEO surface (robots.txt, llms.txt, sitemap.xml, ai-index.json) plus the homepage and up to 10 inner pages, and returns the 0–100 GEO readiness score, the AI crawler access matrix, citability scores, and top fixes.
+
+> "Audit example.com and tell me why ChatGPT can't see it."
+
+### `score_citability`
+
+Score draft content (markdown or plain text) for AI citability — how likely answer engines are to extract and cite it. Returns a 0–100 score across four dimensions with concrete hints. Useful while writing: ask your agent to score and revise a page until it's citable.
+
+> "Score this blog post for AI citability and rewrite the weakest sections."
+
+### `generate_aeo_files`
+
+Generate the full AEO file set (robots.txt, llms.txt, llms-full.txt, sitemap.xml, ai-index.json, schema.json, per-page markdown) into the current project's output directory.
+
+> "Generate AEO files for this project, title 'My Site', url https://mysite.com."
+
+## Notes
+
+- The server speaks newline-delimited JSON-RPC over stdio; logs go to stderr.
+- `audit_url` requires network access; the other tools work offline.
+- Requires Node 18+.


### PR DESCRIPTION
Stacked on #63 (uses the remote scan module) — merge that first; this PR's diff is against `feat/remote-url-check`.

## What

`npx aeo.js mcp` runs a stdio MCP server exposing three tools:

- **`audit_url`** — live GEO readiness scan of any site (score, crawler access matrix, citability, top fixes). *"Audit example.com and tell me why ChatGPT can't see it."*
- **`score_citability`** — score draft content for AI citability with improvement hints; agents can iterate on a page until it's citable.
- **`generate_aeo_files`** — generate the full AEO file set in the current project.

Setup is zero-install: `claude mcp add aeo -- npx -y aeo.js mcp`.

## How

- Minimal newline-delimited JSON-RPC over stdio (`initialize`, `ping`, `tools/list`, `tools/call`, notifications ignored) — **no SDK dependency added**, keeping the package lean.
- Logs to stderr so the protocol stream stays clean.
- Also fixes a pre-existing bug surfaced by `serverInfo`: the `VERSION` constant said 0.0.13 while package.json is 0.0.14 (`--version` was wrong too).
- Docs: `features/mcp` page + sidebar entry.

## Verification

- `tsc --noEmit` clean; 220 tests pass (10 new: initialize/ping/tools-list, citability + audit tool calls with mocked fetch, error paths, notification handling)
- Stdio smoke test against the built CLI: `initialize` and `tools/list` round-trip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)