### PR TITLE
docs(website): add SvelteKit and Remix to sidebar and framework description

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -36,7 +36,7 @@ export default defineConfig({
 		}),
 		starlight({
 			title: 'aeo.js',
-			description: 'Make your website discoverable by ChatGPT, Claude, Perplexity & AI search engines. Auto-generates llms.txt, robots.txt, sitemap, JSON-LD structured data & more. Works with Next.js, Astro, Vite, Nuxt & Angular.',
+			description: 'Make your website discoverable by ChatGPT, Claude, Perplexity & AI search engines. Auto-generates llms.txt, robots.txt, sitemap, JSON-LD structured data & more. Works with Next.js, Astro, Vite, Nuxt, SvelteKit, Remix & Angular.',
 			social: [],
 			components: {
 				Header: './src/components/Header.astro',


### PR DESCRIPTION
## Summary

- Adds SvelteKit and Remix to the Starlight site meta description (alongside Next.js, Astro, Vite, Nuxt, Angular)
- Both framework docs pages (`frameworks/sveltekit.mdx`, `frameworks/remix.mdx`) and their sidebar entries already landed via PR #64 and #65 — this PR covers the one string that was missed

## Test plan

- [ ] Visit the docs sidebar and confirm SvelteKit and Remix entries are present and link correctly
- [ ] Check the page `<meta name="description">` reflects the updated framework list

🤖 Generated with [Claude Code](https://claude.com/claude-code)