### PR TITLE
fix(core): treat missing contentDir as empty in raw markdown copy (#74)

### DIFF
--- a/src/core/raw-markdown.test.ts
+++ b/src/core/raw-markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { copyRawMarkdown, generatePageMarkdownFiles } from './raw-markdown';
-import { readdirSync, statSync, copyFileSync, mkdirSync, writeFileSync } from 'fs';
+import { readdirSync, statSync, copyFileSync, mkdirSync, writeFileSync, existsSync } from 'fs';
 import type { ResolvedAeoConfig } from '../types';
 
 vi.mock('fs', () => ({
@@ -112,6 +112,19 @@ describe('copyRawMarkdown', () => {
 
     expect(result).toEqual([]);
     expect(mockCopyFileSync).not.toHaveBeenCalled();
+  });
+
+  it('does not read or warn when contentDir does not exist (#74)', () => {
+    vi.mocked(existsSync).mockReturnValueOnce(false);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = copyRawMarkdown(createConfig());
+
+    expect(result).toEqual([]);
+    expect(mockReaddirSync).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 
   it('should recursively copy from subdirectories', () => {

--- a/src/core/raw-markdown.ts
+++ b/src/core/raw-markdown.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync, mkdirSync, writeFileSync, copyFileSync } from 'fs';
+import { readdirSync, statSync, mkdirSync, writeFileSync, copyFileSync, existsSync } from 'fs';
 import { join, relative, extname, dirname } from 'path';
 import type { ResolvedAeoConfig } from '../types';
 import { escapeYamlString } from './utils';
@@ -56,7 +56,12 @@ export function copyMarkdownFiles(config: ResolvedAeoConfig): CopiedFile[] {
     }
   }
   
-  copyRecursive(config.contentDir);
+  // A missing contentDir is a valid state (e.g. CMS-backed or page-derived
+  // sites): treat it as an empty content set instead of warning. Mirrors the
+  // existsSync guard used by the manifest/sitemap/llms generators.
+  if (existsSync(config.contentDir)) {
+    copyRecursive(config.contentDir);
+  }
   return copiedFiles;
 }
 


### PR DESCRIPTION
Fixes #74.

## Problem
The Astro integration (and any framework using the core generators) logs a spurious warning during build when the configured/default `contentDir` (`src/content`) does not exist:

```
Warning: Could not read directory src/content: ENOENT ...
```

`copyMarkdownFiles` in `src/core/raw-markdown.ts` called `copyRecursive(config.contentDir)` with no existence check, so a missing directory threw `ENOENT` inside `readdirSync` and got logged. Because `rawMarkdown` is enabled by default, the warning surfaced even when `llmsTxt`/`robotsTxt`/`sitemap` were disabled (as in the #74 repro). This is a legitimate state for CMS-backed or page-derived sites.

## Fix
Guard the copy with `existsSync(config.contentDir)`, mirroring the pattern already used by the `manifest`, `sitemap`, `ai-index`, `llms-txt`, and `llms-full` generators. A missing `contentDir` is now treated as an empty content set — no read, no warning.

## Acceptance criteria
- [x] Regression test: `copyRawMarkdown` performs no directory read and emits no warning when `contentDir` is absent.
- [x] `npx vitest run` — 277 passing.
- [x] `npm run lint` (`tsc --noEmit`) — clean.
- [x] `npm run build` — succeeds.
- Non-goal: the unrelated per-file copy/read warnings inside an existing dir are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)