### PR TITLE
feat: Docusaurus integration (aeo.js/docusaurus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ export default defineNuxtConfig({
 
 Routes are discovered from `src/routes` (TanStack Router file conventions). No build output yet? Use `generate()` instead of `postBuild()` to emit files into `public/` from your source routes.
 
+### Docusaurus
+
+```js
+// docusaurus.config.js
+module.exports = {
+  plugins: [
+    ['aeo.js/docusaurus', { url: 'https://mysite.com', title: 'My Docs' }],
+  ],
+};
+```
+
+`url`, `title`, and `description` default to your Docusaurus `siteConfig` (including `baseUrl`) when omitted. AEO files are generated from the built HTML during `docusaurus build`, and the widget is injected on every page.
+
 ### Angular
 
 ```json

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
       "import": "./dist/tanstack-start.mjs",
       "require": "./dist/tanstack-start.js"
     },
+    "./docusaurus": {
+      "types": "./dist/docusaurus.d.ts",
+      "import": "./dist/docusaurus.mjs",
+      "require": "./dist/docusaurus.js"
+    },
     "./react": {
       "types": "./dist/react.d.ts",
       "import": "./dist/react.mjs",

--- a/src/plugins/docusaurus.test.ts
+++ b/src/plugins/docusaurus.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import aeoDocusaurus from './docusaurus';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let outDir: string;
+
+beforeEach(() => {
+  outDir = mkdtempSync(join(tmpdir(), 'aeo-docusaurus-'));
+});
+
+afterEach(() => {
+  rmSync(outDir, { recursive: true, force: true });
+});
+
+/** Write an HTML page into the build output at a route path. */
+function page(routePath: string, title: string, description: string, body: string): void {
+  const dir = routePath === '/' ? outDir : join(outDir, routePath);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'index.html'),
+    `<html><head><title>${title}</title><meta name="description" content="${description}"></head><body><main><h1>${title}</h1><p>${body}</p></main></body></html>`,
+    'utf-8'
+  );
+}
+
+const context = {
+  siteConfig: { url: 'https://mysite.com', baseUrl: '/', title: 'My Docs', tagline: 'Great docs' },
+};
+
+describe('aeoDocusaurus plugin', () => {
+  it('has the expected plugin name', () => {
+    const plugin = aeoDocusaurus(context, {});
+    expect(plugin.name).toBe('aeo-docusaurus');
+  });
+
+  it('generates AEO files from build output in postBuild', async () => {
+    page('/', 'Home', 'Welcome to my docs', 'This is the homepage content for the docs site.');
+    page('docs/intro', 'Intro', 'Getting started', 'Introduction to the project and how to begin.');
+
+    const plugin = aeoDocusaurus(context, {});
+    await plugin.postBuild({ siteConfig: context.siteConfig, outDir, baseUrl: '/' });
+
+    expect(existsSync(join(outDir, 'sitemap.xml'))).toBe(true);
+    expect(existsSync(join(outDir, 'llms.txt'))).toBe(true);
+    const sitemap = readFileSync(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('https://mysite.com');
+    expect(sitemap).toContain('https://mysite.com/docs/intro');
+  });
+
+  it('defaults url/title/description from the Docusaurus site config', async () => {
+    page('/', 'Home', 'Welcome', 'Homepage content here for testing purposes.');
+    const plugin = aeoDocusaurus(context, {});
+    await plugin.postBuild({ siteConfig: context.siteConfig, outDir, baseUrl: '/' });
+
+    const llms = readFileSync(join(outDir, 'llms.txt'), 'utf-8');
+    expect(llms).toContain('My Docs');
+  });
+
+  it('folds a non-root baseUrl into generated URLs', async () => {
+    page('/', 'Home', 'Welcome', 'Homepage content here for testing purposes.');
+    const projectContext = {
+      siteConfig: { url: 'https://mysite.com', baseUrl: '/project/', title: 'Proj', tagline: 't' },
+    };
+    const plugin = aeoDocusaurus(projectContext, {});
+    await plugin.postBuild({ siteConfig: projectContext.siteConfig, outDir, baseUrl: '/project/' });
+
+    const sitemap = readFileSync(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('https://mysite.com/project');
+  });
+
+  it('lets explicit options override the site config', async () => {
+    page('/', 'Home', 'Welcome', 'Homepage content here for testing purposes.');
+    const plugin = aeoDocusaurus(context, { url: 'https://custom.example', title: 'Custom' });
+    await plugin.postBuild({ siteConfig: context.siteConfig, outDir, baseUrl: '/' });
+
+    const sitemap = readFileSync(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('https://custom.example');
+    expect(sitemap).not.toContain('https://mysite.com');
+  });
+
+  describe('injectHtmlTags', () => {
+    it('injects the widget script by default', () => {
+      const plugin = aeoDocusaurus(context, {});
+      const tags = plugin.injectHtmlTags();
+      expect(tags.postBodyTags).toBeDefined();
+      expect(tags.postBodyTags![0]).toContain("import('aeo.js/widget')");
+    });
+
+    it('injects nothing when the widget is disabled', () => {
+      const plugin = aeoDocusaurus(context, { widget: { enabled: false } });
+      const tags = plugin.injectHtmlTags();
+      expect(tags.postBodyTags).toBeUndefined();
+    });
+  });
+});

--- a/src/plugins/docusaurus.ts
+++ b/src/plugins/docusaurus.ts
@@ -1,0 +1,187 @@
+import { generateAEOFiles } from '../core/generate';
+import { resolveConfig } from '../core/utils';
+import type { AeoConfig, PageEntry } from '../types';
+import { extractTextFromHtml, extractTitle, extractDescription } from '../core/html-extract';
+import { join } from 'path';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+
+/**
+ * The subset of the Docusaurus site config we read. Kept local to avoid a
+ * dependency on @docusaurus/types for a plugin that only needs a few fields.
+ */
+interface DocusaurusSiteConfig {
+  url?: string;
+  baseUrl?: string;
+  title?: string;
+  tagline?: string;
+}
+
+interface DocusaurusContext {
+  siteConfig?: DocusaurusSiteConfig;
+  baseUrl?: string;
+}
+
+interface DocusaurusPostBuildProps {
+  siteConfig?: DocusaurusSiteConfig;
+  outDir: string;
+  baseUrl?: string;
+  routesPaths?: string[];
+}
+
+interface HtmlTags {
+  headTags?: string[];
+  preBodyTags?: string[];
+  postBodyTags?: string[];
+}
+
+interface DocusaurusPlugin {
+  name: string;
+  injectHtmlTags(): HtmlTags;
+  postBuild(props: DocusaurusPostBuildProps): Promise<void>;
+}
+
+/** Build the widget `<script>` tag string, or '' when the widget is disabled. */
+function widgetScriptTag(config: AeoConfig): string {
+  const resolvedConfig = resolveConfig(config);
+  if (!resolvedConfig.widget.enabled) return '';
+
+  const widgetConfig = JSON.stringify({
+    title: resolvedConfig.title,
+    description: resolvedConfig.description,
+    url: resolvedConfig.url,
+    widget: resolvedConfig.widget,
+  })
+    .replace(/&/g, '\\u0026')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
+
+  return `<script type="module">
+import('aeo.js/widget').then(({ AeoWidget }) => {
+  try {
+    new AeoWidget({ config: ${widgetConfig} });
+  } catch (e) {
+    console.warn('[aeo.js] Widget initialization failed:', e);
+  }
+}).catch(() => {});
+</script>`;
+}
+
+/** Scan a build directory tree for prerendered HTML pages. */
+function scanHtmlOutput(outputDir: string): PageEntry[] {
+  const pages: PageEntry[] = [];
+  if (!existsSync(outputDir)) return pages;
+
+  function walk(dir: string, basePath: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      // Skip Docusaurus asset/build internals — they hold no page content.
+      if (stat.isDirectory() && !entry.startsWith('.') && entry !== 'assets' && entry !== 'img') {
+        walk(fullPath, `${basePath}/${entry}`);
+      } else if (entry.endsWith('.html') && entry !== '404.html') {
+        try {
+          const html = readFileSync(fullPath, 'utf-8');
+          const pathname = entry === 'index.html' ? basePath || '/' : `${basePath}/${entry.replace('.html', '')}`;
+          pages.push({
+            pathname,
+            title: extractTitle(html),
+            description: extractDescription(html),
+            content: extractTextFromHtml(html),
+          });
+        } catch {
+          /* skip unreadable file */
+        }
+      }
+    }
+  }
+
+  walk(outputDir, '');
+  return pages;
+}
+
+/**
+ * Resolve the AEO config for a Docusaurus site, defaulting url/title/
+ * description from the Docusaurus site config and folding baseUrl into the
+ * site URL so generated links resolve under a project sub-path.
+ */
+function resolveDocusaurusConfig(options: AeoConfig, siteConfig: DocusaurusSiteConfig = {}, baseUrl?: string): AeoConfig {
+  const base = (baseUrl ?? siteConfig.baseUrl ?? '/').replace(/\/$/, '');
+  const siteUrl = (siteConfig.url ?? '').replace(/\/$/, '');
+  return {
+    ...options,
+    url: options.url || (siteUrl ? siteUrl + base : options.url),
+    title: options.title || siteConfig.title,
+    description: options.description || siteConfig.tagline,
+  };
+}
+
+/**
+ * Docusaurus plugin for AEO.js.
+ *
+ * Injects the AEO widget on every page and, after a production build,
+ * generates robots.txt / sitemap.xml / llms.txt / llms-full.txt and the
+ * manifest from the built HTML output.
+ *
+ * Usage in docusaurus.config.js:
+ *   plugins: [
+ *     ['aeo.js/docusaurus', { url: 'https://mysite.com', title: 'My Docs' }],
+ *   ]
+ *
+ * url/title/description default to the Docusaurus siteConfig when omitted.
+ */
+export default function aeoDocusaurus(context: DocusaurusContext = {}, options: AeoConfig = {}): DocusaurusPlugin {
+  const siteConfig = context.siteConfig ?? {};
+  const injectConfig = resolveDocusaurusConfig(options, siteConfig, context.baseUrl);
+
+  return {
+    name: 'aeo-docusaurus',
+
+    injectHtmlTags() {
+      const script = widgetScriptTag(injectConfig);
+      return script ? { postBodyTags: [script] } : {};
+    },
+
+    async postBuild({ siteConfig: buildSiteConfig, outDir, baseUrl, routesPaths }) {
+      const config = resolveDocusaurusConfig(options, buildSiteConfig ?? siteConfig, baseUrl);
+
+      let pages = scanHtmlOutput(outDir);
+      if (pages.length > 0) {
+        console.log(`[aeo.js] Discovered ${pages.length} pages from Docusaurus build output`);
+      } else if (routesPaths && routesPaths.length > 0) {
+        // No HTML found (unexpected) — fall back to the route paths Docusaurus
+        // reports, without content.
+        pages = routesPaths.map((pathname) => ({ pathname }));
+      }
+
+      // config.pages entries always win over auto-discovered ones.
+      const pageMap = new Map<string, PageEntry>();
+      for (const page of pages) pageMap.set(page.pathname, page);
+      for (const page of options.pages || []) pageMap.set(page.pathname, page);
+
+      const resolvedConfig = resolveConfig({
+        ...config,
+        outDir,
+        pages: Array.from(pageMap.values()),
+      });
+
+      const result = await generateAEOFiles(resolvedConfig);
+      if (result.files.length > 0) {
+        console.log(`[aeo.js] Generated ${result.files.length} files`);
+      }
+      if (result.errors.length > 0) {
+        console.error('[aeo.js] Errors:', result.errors);
+      }
+    },
+  };
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     remix: 'src/plugins/remix.ts',
     sveltekit: 'src/plugins/sveltekit.ts',
     'tanstack-start': 'src/plugins/tanstack-start.ts',
+    docusaurus: 'src/plugins/docusaurus.ts',
     widget: 'src/widget/core.ts',
     react: 'src/widget/react.tsx',
     vue: 'src/widget/vue.ts',


### PR DESCRIPTION
Adds first-class **Docusaurus** support — docs sites are prime content for AI crawlers/LLMs.

## Approach
A Docusaurus plugin using two lifecycle hooks:
- **`postBuild`** — after `docusaurus build`, scans the built HTML in `outDir` (richest source: titles, descriptions, extracted content) and generates robots.txt / sitemap.xml / llms.txt / llms-full.txt / manifest alongside the static output. Falls back to `routesPaths` if no HTML is found.
- **`injectHtmlTags`** — injects the AEO widget `<script>` on every page.

`url` / `title` / `description` default from the Docusaurus `siteConfig` (`url`, `title`, `tagline`), and `baseUrl` is folded into the site URL so project sub-path deployments resolve correctly. Explicit plugin options always override.

```js
// docusaurus.config.js
plugins: [['aeo.js/docusaurus', { url: 'https://mysite.com', title: 'My Docs' }]]
```

## Acceptance criteria
- [x] Unit tests: build-output generation, `siteConfig` defaults, non-root `baseUrl` folding, option overrides, widget injection on/off. **298 tests pass** (7 new).
- [x] `npm run lint` (`tsc --noEmit`) clean — no `any` (local interfaces for the Docusaurus fields used, so no `@docusaurus/types` dependency).
- [x] `npm run build` emits `dist/docusaurus.{js,mjs,d.ts}`.
- [x] Wired: tsup entry, `./docusaurus` export, README section.
- Non-goal: dev-server (`docusaurus start`) generation — `postBuild` is production-only by Docusaurus design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)