### PR TITLE
chore(release): v0.0.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aeo.js",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aeo.js",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "MIT",
       "dependencies": {
         "@types/minimatch": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aeo.js",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Answer Engine Optimization for the modern web. Make your site discoverable by AI crawlers and LLMs.",
   "bin": {
     "aeo.js": "./dist/cli.mjs",


### PR DESCRIPTION
Version bump to **0.0.16** for the changes merged since 0.0.15.

## Included
- fix(core): treat missing `contentDir` as empty in raw markdown copy (#74, PR #78)
- feat: TanStack Start integration `aeo.js/tanstack-start` (#73, PR #79)
- feat: Docusaurus integration `aeo.js/docusaurus` (PR #80)
- chore(deps): undici + website dependency bumps (#72, #77)

## After merge
Cut a **v0.0.16** GitHub release from `main` to trigger the publish workflow (now guarded by the version-vs-tag check and using the rotated npm token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)