### PR TITLE
feat: add optional page tags to ai-index metadata

### DIFF
--- a/src/core/ai-index.test.ts
+++ b/src/core/ai-index.test.ts
@@ -240,6 +240,48 @@ describe('generateAIIndex', () => {
     expect(homeEntry?.metadata?.tags).toBeUndefined();
   });
 
+  it('should omit tags when an empty array is provided', () => {
+    const config: ResolvedAeoConfig = {
+      ...baseConfig,
+      pages: [{ pathname: '/empty-tags', title: 'Empty', tags: [] }],
+    };
+    const result = generateAIIndex(config);
+    const index = JSON.parse(result);
+
+    const entry = index.entries.find((e: any) => e.url === 'https://example.com/empty-tags');
+    expect(entry?.metadata?.tags).toBeUndefined();
+  });
+
+  it('should carry tags on every chunk of multi-chunk content', () => {
+    const config: ResolvedAeoConfig = {
+      ...baseConfig,
+      aiIndex: { ...baseConfig.aiIndex, maxChunkLength: 20 },
+      pages: [
+        {
+          pathname: '/tools/roi',
+          title: 'ROI Calculator',
+          content: [
+            'First paragraph content.',
+            'Second paragraph content.',
+            'Third paragraph content.',
+          ].join('\n\n'),
+          tags: ['calculator', 'template'],
+        },
+      ],
+    };
+
+    const result = generateAIIndex(config);
+    const index = JSON.parse(result);
+    const chunks = index.entries
+      .filter((e: any) => e.url === 'https://example.com/tools/roi')
+      .sort((a: any, b: any) => a.metadata.chunkIndex - b.metadata.chunkIndex);
+
+    expect(chunks).toHaveLength(3);
+    for (const chunk of chunks) {
+      expect(chunk.metadata.tags).toEqual(['calculator', 'template']);
+    }
+  });
+
   it('should handle empty pages', () => {
     const config: ResolvedAeoConfig = { ...baseConfig, pages: [] };
     const result = generateAIIndex(config);

--- a/src/core/ai-index.test.ts
+++ b/src/core/ai-index.test.ts
@@ -203,6 +203,43 @@ describe('generateAIIndex', () => {
     expect(contactEntry?.title).toBe('Contact');
   });
 
+  it('should surface page tags verbatim in entry metadata', () => {
+    const config: ResolvedAeoConfig = {
+      ...baseConfig,
+      pages: [
+        {
+          pathname: '/tools/roi',
+          title: 'ROI Calculator',
+          description: 'Estimate return on investment',
+          content: 'Use this calculator to estimate ROI for your campaign.',
+          tags: ['calculator', 'template'],
+        },
+        {
+          pathname: '/guides/setup',
+          title: 'Setup Guide',
+          tags: ['guide'],
+        },
+      ],
+    };
+
+    const result = generateAIIndex(config);
+    const index = JSON.parse(result);
+
+    const roiEntry = index.entries.find((e: any) => e.url === 'https://example.com/tools/roi');
+    expect(roiEntry?.metadata?.tags).toEqual(['calculator', 'template']);
+
+    const guideEntry = index.entries.find((e: any) => e.url === 'https://example.com/guides/setup');
+    expect(guideEntry?.metadata?.tags).toEqual(['guide']);
+  });
+
+  it('should omit tags from metadata when not provided', () => {
+    const result = generateAIIndex(baseConfig);
+    const index = JSON.parse(result);
+
+    const homeEntry = index.entries.find((e: any) => e.url === 'https://example.com');
+    expect(homeEntry?.metadata?.tags).toBeUndefined();
+  });
+
   it('should handle empty pages', () => {
     const config: ResolvedAeoConfig = { ...baseConfig, pages: [] };
     const result = generateAIIndex(config);

--- a/src/core/ai-index.ts
+++ b/src/core/ai-index.ts
@@ -137,7 +137,7 @@ export function generateAIIndex(config: ResolvedAeoConfig): string {
               chunkIndex: index,
               totalChunks: chunks.length,
               sourcePath: page.pathname,
-              ...(page.tags !== undefined ? { tags: page.tags } : {}),
+              ...(page.tags?.length ? { tags: page.tags } : {}),
             },
           });
         });
@@ -154,7 +154,7 @@ export function generateAIIndex(config: ResolvedAeoConfig): string {
           content: page.description || title,
           description: page.description,
           keywords: [],
-          ...(page.tags !== undefined
+          ...(page.tags?.length
             ? { metadata: { tags: page.tags } }
             : {}),
         });

--- a/src/core/ai-index.ts
+++ b/src/core/ai-index.ts
@@ -137,6 +137,7 @@ export function generateAIIndex(config: ResolvedAeoConfig): string {
               chunkIndex: index,
               totalChunks: chunks.length,
               sourcePath: page.pathname,
+              ...(page.tags !== undefined ? { tags: page.tags } : {}),
             },
           });
         });
@@ -153,6 +154,9 @@ export function generateAIIndex(config: ResolvedAeoConfig): string {
           content: page.description || title,
           description: page.description,
           keywords: [],
+          ...(page.tags !== undefined
+            ? { metadata: { tags: page.tags } }
+            : {}),
         });
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@ export interface PageEntry {
   title?: string;
   description?: string;
   content?: string;
+  /** User-defined labels (e.g. 'calculator', 'template'). Surfaced in ai-index.json metadata only. */
+  tags?: string[];
 }
 
 export interface AeoConfig {

--- a/website/src/content/docs/features/generated-files.mdx
+++ b/website/src/content/docs/features/generated-files.mdx
@@ -71,17 +71,25 @@ A structured documentation manifest:
 An AI-optimized content index designed for RAG (Retrieval-Augmented Generation) pipelines:
 
 ```json
-[
-  {
-    "id": "index",
-    "url": "https://mysite.com/",
-    "title": "Home",
-    "content": "Full page content in markdown...",
-    "description": "Page description",
-    "keywords": ["keyword1", "keyword2"]
-  }
-]
+{
+  "version": "1.0",
+  "entries": [
+    {
+      "id": "…",
+      "url": "https://mysite.com/tools/roi",
+      "title": "ROI Calculator",
+      "content": "Full page content in markdown...",
+      "description": "Page description",
+      "keywords": ["keyword1", "keyword2"],
+      "metadata": {
+        "tags": ["calculator", "template"]
+      }
+    }
+  ]
+}
 ```
+
+Optional `PageEntry.tags` values are copied into each entry's `metadata.tags` for downstream tools. They are informational only and do not change scoring.
 
 ## Raw Markdown
 

--- a/website/src/content/docs/reference/configuration.mdx
+++ b/website/src/content/docs/reference/configuration.mdx
@@ -96,6 +96,16 @@ export default defineConfig({
 | `outDir` | `string` | auto-detected | Output directory for generated files |
 | `pages` | `PageEntry[]` | `[]` | Manually specify pages to include |
 
+### `pages` (`PageEntry`)
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `pathname` | `string` | — | Page path (e.g. `/about`) |
+| `title` | `string` | — | Page title |
+| `description` | `string` | — | Page description |
+| `content` | `string` | — | Page body used for AI index chunks and keywords |
+| `tags` | `string[]` | — | Optional user-defined labels (e.g. `'calculator'`, `'template'`, `'guide'`). Surfaced verbatim in `ai-index.json` entry `metadata.tags`. Descriptive only — does not affect audit or citability scoring. |
+
 ### `generators`
 
 | Option | Type | Default | Description |


### PR DESCRIPTION
## Summary
- Adds optional `PageEntry.tags?: string[]` for user-defined page labels (e.g. `calculator`, `template`, `guide`)
- Surfaces tags verbatim in `ai-index.json` entry `metadata.tags` (descriptive only — no audit/citability impact)
- Documents the field in the configuration and generated-files reference

Closes #54

## Test plan
- [x] `npm test -- --run src/core/ai-index.test.ts` (12 passing, including new tags cases)
- [x] `npx tsc --noEmit`
- [ ] Spot-check: configure a page with `tags: ['calculator']` and confirm `ai-index.json` includes `metadata.tags`