### PR TITLE
feat: Eleventy (11ty) integration (aeo.js/eleventy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,19 @@ module.exports = {
 
 `url`, `title`, and `description` default to your Docusaurus `siteConfig` (including `baseUrl`) when omitted. AEO files are generated from the built HTML during `docusaurus build`, and the widget is injected on every page.
 
+### Eleventy
+
+```js
+// eleventy.config.js
+const aeo = require('aeo.js/eleventy');
+
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addPlugin(aeo, { url: 'https://mysite.com', title: 'My Site' });
+};
+```
+
+Requires Eleventy 2.0+. AEO files are generated from the rendered output into your Eleventy output directory (`_site` by default), and the widget is injected into every HTML page.
+
 ### Angular
 
 ```json

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
       "import": "./dist/docusaurus.mjs",
       "require": "./dist/docusaurus.js"
     },
+    "./eleventy": {
+      "types": "./dist/eleventy.d.ts",
+      "import": "./dist/eleventy.mjs",
+      "require": "./dist/eleventy.js"
+    },
     "./react": {
       "types": "./dist/react.d.ts",
       "import": "./dist/react.mjs",

--- a/src/plugins/eleventy.test.ts
+++ b/src/plugins/eleventy.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import aeoEleventy from './eleventy';
+import { mkdtempSync, readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/** Minimal mock of the Eleventy config API, capturing registered hooks. */
+function createMockConfig() {
+  const transforms: Record<string, (content: string, outputPath?: string) => string> = {};
+  const events: Record<string, (arg: any) => void | Promise<void>> = {};
+  return {
+    transforms,
+    events,
+    addTransform(name: string, fn: any) {
+      transforms[name] = fn;
+    },
+    on(event: string, fn: any) {
+      events[event] = fn;
+    },
+  };
+}
+
+const html = (title: string, desc: string, body: string) =>
+  `<html><head><title>${title}</title><meta name="description" content="${desc}"></head><body><main><h1>${title}</h1><p>${body}</p></main></body></html>`;
+
+let outDir: string;
+
+beforeEach(() => {
+  outDir = mkdtempSync(join(tmpdir(), 'aeo-eleventy-'));
+});
+
+afterEach(() => {
+  rmSync(outDir, { recursive: true, force: true });
+});
+
+describe('aeoEleventy', () => {
+  it('generates AEO files from build results in eleventy.after', async () => {
+    const config = createMockConfig();
+    aeoEleventy(config as any, { url: 'https://mysite.com', title: 'My Site' });
+
+    await config.events['eleventy.after']({
+      directories: { output: outDir },
+      results: [
+        { outputPath: join(outDir, 'index.html'), url: '/', content: html('Home', 'Welcome', 'Homepage body content for testing.') },
+        { outputPath: join(outDir, 'about', 'index.html'), url: '/about/', content: html('About', 'About us', 'About page body content here.') },
+      ],
+    });
+
+    expect(existsSync(join(outDir, 'sitemap.xml'))).toBe(true);
+    const sitemap = readFileSync(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('https://mysite.com');
+    // Trailing slash from Eleventy URLs is normalized away.
+    expect(sitemap).toContain('https://mysite.com/about');
+    expect(sitemap).not.toContain('/about/</loc>');
+  });
+
+  it('falls back to dir.output (Eleventy 2.x) and skips non-HTML + 404 results', async () => {
+    const config = createMockConfig();
+    aeoEleventy(config as any, { url: 'https://mysite.com' });
+
+    await config.events['eleventy.after']({
+      dir: { output: outDir },
+      results: [
+        { outputPath: join(outDir, 'index.html'), url: '/', content: html('Home', 'Welcome', 'Body content.') },
+        { outputPath: join(outDir, 'style.css'), url: '/style.css', content: 'body{}' },
+        { outputPath: join(outDir, '404.html'), url: '/404/', content: html('Not found', '', 'x') },
+      ],
+    });
+
+    const sitemap = readFileSync(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('<loc>https://mysite.com</loc>');
+    expect(sitemap).not.toContain('style.css');
+    expect(sitemap).not.toContain('/404');
+  });
+
+  it('lets config.pages override discovered pages', async () => {
+    const config = createMockConfig();
+    aeoEleventy(config as any, { url: 'https://mysite.com', pages: [{ pathname: '/custom', title: 'Custom' }] });
+
+    await config.events['eleventy.after']({
+      directories: { output: outDir },
+      results: [{ outputPath: join(outDir, 'index.html'), url: '/', content: html('Home', 'Welcome', 'Body.') }],
+    });
+
+    const sitemap = readFileSync(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('https://mysite.com/custom');
+  });
+
+  describe('widget transform', () => {
+    it('injects the widget script into HTML output by default', () => {
+      const config = createMockConfig();
+      aeoEleventy(config as any, { url: 'https://mysite.com' });
+
+      const transform = config.transforms['aeo-widget'];
+      expect(transform).toBeDefined();
+
+      const input = '<html><body><h1>Hi</h1></body></html>';
+      const output = transform.call({ page: { outputPath: join(outDir, 'index.html') } }, input);
+      expect(output).toContain("import('aeo.js/widget')");
+      expect(output.indexOf("import('aeo.js/widget')")).toBeLessThan(output.indexOf('</body>'));
+    });
+
+    it('leaves non-HTML output untouched', () => {
+      const config = createMockConfig();
+      aeoEleventy(config as any, { url: 'https://mysite.com' });
+
+      const transform = config.transforms['aeo-widget'];
+      const css = 'body { color: red; }';
+      const output = transform.call({ page: { outputPath: join(outDir, 'style.css') } }, css);
+      expect(output).toBe(css);
+    });
+
+    it('registers no transform when the widget is disabled', () => {
+      const config = createMockConfig();
+      aeoEleventy(config as any, { url: 'https://mysite.com', widget: { enabled: false } });
+      expect(config.transforms['aeo-widget']).toBeUndefined();
+    });
+  });
+});

--- a/src/plugins/eleventy.ts
+++ b/src/plugins/eleventy.ts
@@ -1,0 +1,128 @@
+import { generateAEOFiles } from '../core/generate';
+import { resolveConfig } from '../core/utils';
+import type { AeoConfig, PageEntry } from '../types';
+import { extractTextFromHtml, extractTitle, extractDescription } from '../core/html-extract';
+
+/**
+ * The subset of Eleventy's config API we use. Kept local to avoid a dependency
+ * on @11ty/eleventy for a plugin that only registers a transform and an event.
+ */
+interface EleventyConfig {
+  addTransform(name: string, transform: (this: EleventyTransformThis, content: string, outputPath?: string) => string): void;
+  on(event: string, handler: (arg: EleventyAfterEvent) => void | Promise<void>): void;
+}
+
+interface EleventyTransformThis {
+  page?: { outputPath?: string | false; url?: string };
+}
+
+interface EleventyResult {
+  inputPath?: string;
+  outputPath?: string | false;
+  url?: string;
+  content?: string;
+}
+
+interface EleventyDirectories {
+  output?: string;
+}
+
+interface EleventyAfterEvent {
+  // Eleventy 3.x passes `directories`; 2.x passed `dir`. Support both.
+  directories?: EleventyDirectories;
+  dir?: EleventyDirectories;
+  results?: EleventyResult[];
+}
+
+/** Build the widget `<script>` tag string, or '' when the widget is disabled. */
+function widgetScriptTag(config: AeoConfig): string {
+  const resolvedConfig = resolveConfig(config);
+  if (!resolvedConfig.widget.enabled) return '';
+
+  const widgetConfig = JSON.stringify({
+    title: resolvedConfig.title,
+    description: resolvedConfig.description,
+    url: resolvedConfig.url,
+    widget: resolvedConfig.widget,
+  })
+    .replace(/&/g, '\\u0026')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
+
+  return `<script type="module">
+import('aeo.js/widget').then(({ AeoWidget }) => {
+  try {
+    new AeoWidget({ config: ${widgetConfig} });
+  } catch (e) {
+    console.warn('[aeo.js] Widget initialization failed:', e);
+  }
+}).catch(() => {});
+</script>`;
+}
+
+/** Normalize an Eleventy URL to a clean pathname (strip trailing slash, keep root). */
+function normalizePathname(url: string): string {
+  if (!url || url === '/') return '/';
+  const clean = url.replace(/\/+$/, '');
+  return clean === '' ? '/' : clean;
+}
+
+/**
+ * Eleventy plugin for AEO.js (Eleventy 2.0+).
+ *
+ * Injects the AEO widget into every HTML page and, after the build, generates
+ * robots.txt / sitemap.xml / llms.txt / llms-full.txt / ai-index.json / the
+ * manifest from the rendered output into your Eleventy output directory.
+ *
+ * Usage in eleventy.config.js:
+ *   const aeo = require('aeo.js/eleventy');
+ *   module.exports = function (eleventyConfig) {
+ *     eleventyConfig.addPlugin(aeo, { url: 'https://mysite.com', title: 'My Site' });
+ *   };
+ */
+export default function aeoEleventy(eleventyConfig: EleventyConfig, options: AeoConfig = {}): void {
+  const script = widgetScriptTag(options);
+
+  if (script) {
+    eleventyConfig.addTransform('aeo-widget', function (this: EleventyTransformThis, content: string, outputPath?: string) {
+      const out = this.page?.outputPath || outputPath || '';
+      if (typeof out === 'string' && out.endsWith('.html') && content.includes('</body>')) {
+        return content.replace('</body>', `${script}\n</body>`);
+      }
+      return content;
+    });
+  }
+
+  eleventyConfig.on('eleventy.after', async ({ directories, dir, results }: EleventyAfterEvent) => {
+    const outputDir = options.outDir || directories?.output || dir?.output || '_site';
+
+    const discovered: PageEntry[] = (results || [])
+      .filter((r) => typeof r.outputPath === 'string' && r.outputPath.endsWith('.html'))
+      .map((r) => ({
+        pathname: normalizePathname(r.url || '/'),
+        title: r.content ? extractTitle(r.content) : undefined,
+        description: r.content ? extractDescription(r.content) : undefined,
+        content: r.content ? extractTextFromHtml(r.content) : undefined,
+      }))
+      .filter((p) => !p.pathname.startsWith('/404'));
+
+    // config.pages entries always win over auto-discovered ones.
+    const pageMap = new Map<string, PageEntry>();
+    for (const page of discovered) pageMap.set(page.pathname, page);
+    for (const page of options.pages || []) pageMap.set(page.pathname, page);
+
+    const pages = Array.from(pageMap.values());
+    if (pages.length > 0) {
+      console.log(`[aeo.js] Discovered ${pages.length} pages from Eleventy build output`);
+    }
+
+    const resolvedConfig = resolveConfig({ ...options, outDir: outputDir, pages });
+    const result = await generateAEOFiles(resolvedConfig);
+    if (result.files.length > 0) {
+      console.log(`[aeo.js] Generated ${result.files.length} files`);
+    }
+    if (result.errors.length > 0) {
+      console.error('[aeo.js] Errors:', result.errors);
+    }
+  });
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     sveltekit: 'src/plugins/sveltekit.ts',
     'tanstack-start': 'src/plugins/tanstack-start.ts',
     docusaurus: 'src/plugins/docusaurus.ts',
+    eleventy: 'src/plugins/eleventy.ts',
     widget: 'src/widget/core.ts',
     react: 'src/widget/react.tsx',
     vue: 'src/widget/vue.ts',

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -72,6 +72,7 @@ export default defineConfig({
 						{ label: 'TanStack Start', slug: 'frameworks/tanstack-start' },
 						{ label: 'Angular', slug: 'frameworks/angular' },
 						{ label: 'Docusaurus', slug: 'frameworks/docusaurus' },
+						{ label: 'Eleventy', slug: 'frameworks/eleventy' },
 						{ label: 'Webpack', slug: 'frameworks/webpack' },
 						{ label: 'Vanilla JS / Static HTML', slug: 'frameworks/vanilla' },
 					],

--- a/website/src/content/docs/frameworks/eleventy.mdx
+++ b/website/src/content/docs/frameworks/eleventy.mdx
@@ -1,0 +1,60 @@
+---
+title: Eleventy
+description: Use aeo.js with Eleventy (11ty) static sites.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+## Setup
+
+<Steps>
+1. Install the package:
+   ```bash
+   npm install aeo.js
+   ```
+
+2. Add the plugin in your `eleventy.config.js`:
+   ```js
+   const aeo = require('aeo.js/eleventy');
+
+   module.exports = function (eleventyConfig) {
+     eleventyConfig.addPlugin(aeo, {
+       url: 'https://mysite.com',
+       title: 'My Site',
+     });
+   };
+   ```
+
+3. Build your site:
+   ```bash
+   npx @11ty/eleventy
+   ```
+</Steps>
+
+<Aside type="caution">
+Requires Eleventy **2.0 or newer** — the plugin uses the `eleventy.after` event's `results` API and the `directories` argument.
+</Aside>
+
+## How it works
+
+The Eleventy plugin:
+
+- Registers a transform that injects the AEO widget into every rendered `.html` page
+- Listens for the `eleventy.after` event and reads Eleventy's build `results` — each page's URL and rendered HTML — to extract titles, descriptions, and full text content
+- Normalizes Eleventy's trailing-slash URLs (`/about/` → `/about`) and skips non-HTML output and 404 pages
+- Generates all AEO files (robots.txt, llms.txt, sitemap.xml, ai-index.json, …) into your Eleventy output directory (`_site` by default)
+
+## Configuration
+
+Pass any [AeoConfig](/reference/configuration/) options as the second argument to `addPlugin`. Add pages that Eleventy doesn't emit as HTML via `pages` — your entries always win over auto-discovered ones:
+
+```js
+eleventyConfig.addPlugin(aeo, {
+  url: 'https://mysite.com',
+  title: 'My Site',
+  description: 'A site optimized for AI discovery',
+  schema: { organization: { name: 'My Company' } },
+});
+```
+
+If your output directory isn't the default `_site`, either pass `outDir` or rely on the `directories` value Eleventy reports — the plugin reads it automatically.


### PR DESCRIPTION
Adds first-class **Eleventy (11ty)** support — static content sites/blogs/docs are a core AEO audience.

## Approach
An Eleventy plugin (`addPlugin`) using two hooks:
- **`addTransform('aeo-widget', …)`** — injects the AEO widget `<script>` before `</body>` on every rendered `.html` page.
- **`eleventy.after`** — reads Eleventy's build `results` (each page's `url` + rendered HTML) to extract titles, descriptions, and full text content, then generates robots.txt / sitemap.xml / llms.txt / llms-full.txt / ai-index.json / manifest into the output directory.

Trailing-slash URLs (`/about/`) are normalized to `/about`; non-HTML output and 404 pages are skipped. Output dir resolves from `directories.output` (3.x) or `dir.output` (2.x), overridable via `outDir` (default `_site`).

```js
// eleventy.config.js
const aeo = require('aeo.js/eleventy');
module.exports = (eleventyConfig) => {
  eleventyConfig.addPlugin(aeo, { url: 'https://mysite.com', title: 'My Site' });
};
```

## Acceptance criteria
- [x] Unit tests (mock Eleventy config): file generation from `results`, `dir.output` 2.x fallback, non-HTML/404 skipping, `config.pages` override, widget transform inject/skip/disabled. **308 tests pass** (6 new).
- [x] `npm run lint` (`tsc --noEmit`) clean — no `any` (local interfaces for the Eleventy surface used, so no `@11ty/eleventy` dependency).
- [x] `npm run build` emits `dist/eleventy.{js,mjs,d.ts}`.
- [x] Wired: tsup entry, `./eleventy` export, README, website docs page + sidebar (website builds clean).
- Requires Eleventy 2.0+ (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)