### PR TITLE
feat: VitePress integration (aeo.js/vitepress)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,21 @@ module.exports = function (eleventyConfig) {
 
 Requires Eleventy 2.0+. AEO files are generated from the rendered output into your Eleventy output directory (`_site` by default), and the widget is injected into every HTML page.
 
+### VitePress
+
+```ts
+// .vitepress/config.ts
+import { defineConfig } from 'vitepress';
+import { withAeo } from 'aeo.js/vitepress';
+
+export default defineConfig(withAeo({
+  title: 'My Docs',
+  // …your VitePress config…
+}, { url: 'https://mysite.com' }));
+```
+
+`withAeo` wraps your config: it collects pages during `vitepress build`, injects the widget, and generates AEO files into the output directory. `url`, `title`, and `description` default from your VitePress site config (and `sitemap.hostname`).
+
 ### Angular
 
 ```json

--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
       "import": "./dist/eleventy.mjs",
       "require": "./dist/eleventy.js"
     },
+    "./vitepress": {
+      "types": "./dist/vitepress.d.ts",
+      "import": "./dist/vitepress.mjs",
+      "require": "./dist/vitepress.js"
+    },
     "./react": {
       "types": "./dist/react.d.ts",
       "import": "./dist/react.mjs",

--- a/src/plugins/vitepress.test.ts
+++ b/src/plugins/vitepress.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { withAeo, getWidgetScript } from './vitepress';
+import { mkdtempSync, readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const html = (title: string, desc: string, body: string) =>
+  `<html><head><title>${title}</title><meta name="description" content="${desc}"></head><body><h1>${title}</h1><p>${body}</p></body></html>`;
+
+const ctx = (page: string, title: string, desc: string) => ({
+  page,
+  pageData: { relativePath: page, title, description: desc },
+  title,
+  description: desc,
+});
+
+let outDir: string;
+
+beforeEach(() => {
+  outDir = mkdtempSync(join(tmpdir(), 'aeo-vitepress-'));
+});
+
+afterEach(() => {
+  rmSync(outDir, { recursive: true, force: true });
+});
+
+describe('withAeo', () => {
+  it('collects pages via transformHtml and generates AEO files in buildEnd', async () => {
+    const config = withAeo({}, { url: 'https://mysite.com', title: 'My Docs' });
+
+    await config.transformHtml!(html('Home', 'Welcome', 'Homepage content body.'), 'index.html', ctx('index.md', 'Home', 'Welcome'));
+    await config.transformHtml!(html('Guide', 'The guide', 'Guide content body here.'), 'guide.html', ctx('guide/index.md', 'Guide', 'The guide'));
+
+    await config.buildEnd!({ outDir, site: { title: 'My Docs', description: 'Docs' } });
+
+    expect(existsSync(join(outDir, 'sitemap.xml'))).toBe(true);
+    const sitemap = readFileSync(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('<loc>https://mysite.com</loc>');
+    expect(sitemap).toContain('https://mysite.com/guide');
+  });
+
+  it('injects the widget before </body> during transformHtml', async () => {
+    const config = withAeo({}, { url: 'https://mysite.com' });
+    const out = (await config.transformHtml!('<html><body><h1>Hi</h1></body></html>', 'index.html', ctx('index.md', 'Hi', ''))) as string;
+    expect(out).toContain("import('aeo.js/widget')");
+    expect(out.indexOf("import('aeo.js/widget')")).toBeLessThan(out.indexOf('</body>'));
+  });
+
+  it('does not inject when the widget is disabled', async () => {
+    const config = withAeo({}, { url: 'https://mysite.com', widget: { enabled: false } });
+    const input = '<html><body><h1>Hi</h1></body></html>';
+    const out = (await config.transformHtml!(input, 'index.html', ctx('index.md', 'Hi', ''))) as string;
+    expect(out).toBe(input);
+  });
+
+  it('defaults url from sitemap.hostname and title from site config', async () => {
+    const config = withAeo({}, {});
+    await config.transformHtml!(html('Home', 'Welcome', 'Body content here.'), 'index.html', ctx('index.md', 'Home', 'Welcome'));
+    await config.buildEnd!({ outDir, site: { title: 'Site Title', description: 'd' }, sitemap: { hostname: 'https://fromsitemap.com' } });
+
+    const sitemap = readFileSync(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('https://fromsitemap.com');
+    const llms = readFileSync(join(outDir, 'llms.txt'), 'utf-8');
+    expect(llms).toContain('Site Title');
+  });
+
+  it('preserves user-defined transformHtml and buildEnd hooks', async () => {
+    const userTransform = vi.fn((code: string) => code.replace('<h1>', '<h1 data-user="1">'));
+    const userBuildEnd = vi.fn();
+    const config = withAeo({ transformHtml: userTransform, buildEnd: userBuildEnd }, { url: 'https://mysite.com' });
+
+    const out = (await config.transformHtml!('<html><body><h1>Hi</h1></body></html>', 'index.html', ctx('index.md', 'Hi', ''))) as string;
+    expect(userTransform).toHaveBeenCalled();
+    expect(out).toContain('data-user="1"'); // user transform applied
+    expect(out).toContain("import('aeo.js/widget')"); // and ours too
+
+    await config.buildEnd!({ outDir, site: {} });
+    expect(userBuildEnd).toHaveBeenCalled();
+  });
+
+  it('lets config.pages override discovered pages', async () => {
+    const config = withAeo({}, { url: 'https://mysite.com', pages: [{ pathname: '/custom', title: 'Custom' }] });
+    await config.transformHtml!(html('Home', 'W', 'Body.'), 'index.html', ctx('index.md', 'Home', 'W'));
+    await config.buildEnd!({ outDir, site: {} });
+
+    const sitemap = readFileSync(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('https://mysite.com/custom');
+  });
+});
+
+describe('getWidgetScript', () => {
+  it('returns a script when enabled and empty string when disabled', () => {
+    expect(getWidgetScript({ url: 'https://mysite.com' })).toContain("import('aeo.js/widget')");
+    expect(getWidgetScript({ url: 'https://mysite.com', widget: { enabled: false } })).toBe('');
+  });
+});

--- a/src/plugins/vitepress.ts
+++ b/src/plugins/vitepress.ts
@@ -1,0 +1,162 @@
+import { generateAEOFiles } from '../core/generate';
+import { resolveConfig } from '../core/utils';
+import type { AeoConfig, PageEntry } from '../types';
+import { extractTextFromHtml, extractTitle, extractDescription } from '../core/html-extract';
+
+/**
+ * The subset of VitePress config types we touch. Kept local to avoid a
+ * dependency on `vitepress` for a wrapper that only composes two build hooks.
+ */
+interface VitePressTransformContext {
+  page: string;
+  pageData?: {
+    relativePath?: string;
+    title?: string;
+    description?: string;
+    frontmatter?: Record<string, unknown>;
+  };
+  title?: string;
+  description?: string;
+  content?: string;
+}
+
+interface VitePressSiteConfig {
+  outDir: string;
+  site?: { title?: string; description?: string };
+  sitemap?: { hostname?: string };
+}
+
+export interface VitePressUserConfig {
+  transformHtml?: (code: string, id: string, ctx: VitePressTransformContext) => string | void | Promise<string | void>;
+  buildEnd?: (siteConfig: VitePressSiteConfig) => void | Promise<void>;
+}
+
+/** Build the widget `<script>` tag string, or '' when the widget is disabled. */
+function widgetScriptTag(config: AeoConfig): string {
+  const resolvedConfig = resolveConfig(config);
+  if (!resolvedConfig.widget.enabled) return '';
+
+  const widgetConfig = JSON.stringify({
+    title: resolvedConfig.title,
+    description: resolvedConfig.description,
+    url: resolvedConfig.url,
+    widget: resolvedConfig.widget,
+  })
+    .replace(/&/g, '\\u0026')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
+
+  return `<script type="module">
+import('aeo.js/widget').then(({ AeoWidget }) => {
+  try {
+    new AeoWidget({ config: ${widgetConfig} });
+  } catch (e) {
+    console.warn('[aeo.js] Widget initialization failed:', e);
+  }
+}).catch(() => {});
+</script>`;
+}
+
+/** Map a VitePress source page (e.g. `guide/index.md`) to a clean pathname. */
+function pageToPathname(page: string): string {
+  let p = page.replace(/\.md$/, '');
+  p = p.replace(/(^|\/)index$/, '$1');
+  p = '/' + p.replace(/^\/+/, '');
+  return p.replace(/\/+$/, '') || '/';
+}
+
+/**
+ * Wrap a VitePress config to add AEO.js support.
+ *
+ * During `vitepress build` it collects each page's rendered HTML (via the
+ * `transformHtml` hook), injects the AEO widget, and after the build writes
+ * robots.txt / sitemap.xml / llms.txt / llms-full.txt / ai-index.json / the
+ * manifest into the output directory (via `buildEnd`). Any `transformHtml` /
+ * `buildEnd` you already define are preserved and run first.
+ *
+ * Usage in .vitepress/config.ts:
+ *   import { defineConfig } from 'vitepress';
+ *   import { withAeo } from 'aeo.js/vitepress';
+ *
+ *   export default defineConfig(withAeo({
+ *     title: 'My Docs',
+ *     // …your VitePress config…
+ *   }, { url: 'https://mysite.com' }));
+ *
+ * url/title/description default from the VitePress site config (and
+ * `sitemap.hostname`) when omitted.
+ */
+export function withAeo<T extends VitePressUserConfig>(
+  config: T,
+  options: AeoConfig = {}
+): Omit<T, 'transformHtml' | 'buildEnd'> & Required<VitePressUserConfig> {
+  const script = widgetScriptTag(options);
+  const collected = new Map<string, PageEntry>();
+
+  const userTransformHtml = config.transformHtml;
+  const userBuildEnd = config.buildEnd;
+
+  return {
+    ...config,
+
+    async transformHtml(code: string, id: string, ctx: VitePressTransformContext) {
+      let out = code;
+      if (userTransformHtml) {
+        const result = await userTransformHtml(out, id, ctx);
+        if (typeof result === 'string') out = result;
+      }
+
+      const source = ctx.pageData?.relativePath || ctx.page;
+      if (source) {
+        const pathname = pageToPathname(source);
+        if (!pathname.startsWith('/404')) {
+          collected.set(pathname, {
+            pathname,
+            title: ctx.pageData?.title || ctx.title || undefined,
+            description: ctx.pageData?.description || ctx.description || undefined,
+            content: extractTextFromHtml(out) || undefined,
+          });
+        }
+      }
+
+      if (script && out.includes('</body>')) {
+        out = out.replace('</body>', `${script}\n</body>`);
+      }
+      return out;
+    },
+
+    async buildEnd(siteConfig: VitePressSiteConfig) {
+      if (userBuildEnd) await userBuildEnd(siteConfig);
+
+      const config2: AeoConfig = {
+        ...options,
+        url: options.url || siteConfig.sitemap?.hostname || options.url,
+        title: options.title || siteConfig.site?.title,
+        description: options.description || siteConfig.site?.description,
+      };
+
+      // config.pages entries always win over auto-discovered ones.
+      const pageMap = new Map<string, PageEntry>(collected);
+      for (const page of options.pages || []) pageMap.set(page.pathname, page);
+
+      const pages = Array.from(pageMap.values());
+      if (pages.length > 0) {
+        console.log(`[aeo.js] Discovered ${pages.length} pages from VitePress build`);
+      }
+
+      const resolvedConfig = resolveConfig({ ...config2, outDir: siteConfig.outDir, pages });
+      const result = await generateAEOFiles(resolvedConfig);
+      if (result.files.length > 0) {
+        console.log(`[aeo.js] Generated ${result.files.length} files`);
+      }
+      if (result.errors.length > 0) {
+        console.error('[aeo.js] Errors:', result.errors);
+      }
+    },
+  };
+}
+
+export default withAeo;
+
+// Re-export so consumers can also inject the widget manually if they prefer.
+export { widgetScriptTag as getWidgetScript };

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     'tanstack-start': 'src/plugins/tanstack-start.ts',
     docusaurus: 'src/plugins/docusaurus.ts',
     eleventy: 'src/plugins/eleventy.ts',
+    vitepress: 'src/plugins/vitepress.ts',
     widget: 'src/widget/core.ts',
     react: 'src/widget/react.tsx',
     vue: 'src/widget/vue.ts',

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -73,6 +73,7 @@ export default defineConfig({
 						{ label: 'Angular', slug: 'frameworks/angular' },
 						{ label: 'Docusaurus', slug: 'frameworks/docusaurus' },
 						{ label: 'Eleventy', slug: 'frameworks/eleventy' },
+						{ label: 'VitePress', slug: 'frameworks/vitepress' },
 						{ label: 'Webpack', slug: 'frameworks/webpack' },
 						{ label: 'Vanilla JS / Static HTML', slug: 'frameworks/vanilla' },
 					],

--- a/website/src/content/docs/frameworks/vitepress.mdx
+++ b/website/src/content/docs/frameworks/vitepress.mdx
@@ -1,0 +1,62 @@
+---
+title: VitePress
+description: Use aeo.js with VitePress documentation sites.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+## Setup
+
+<Steps>
+1. Install the package:
+   ```bash
+   npm install aeo.js
+   ```
+
+2. Wrap your config in `.vitepress/config.ts`:
+   ```ts
+   import { defineConfig } from 'vitepress';
+   import { withAeo } from 'aeo.js/vitepress';
+
+   export default defineConfig(
+     withAeo(
+       {
+         title: 'My Docs',
+         description: 'My documentation site',
+         // …the rest of your VitePress config…
+       },
+       { url: 'https://mysite.com' }
+     )
+   );
+   ```
+
+3. Build your site:
+   ```bash
+   npm run docs:build
+   ```
+</Steps>
+
+## How it works
+
+`withAeo(config, options)` wraps your VitePress config and composes two build hooks:
+
+- **`transformHtml`** — runs per page during the build. It collects each page's URL, title, description, and rendered text content, and injects the AEO widget before `</body>`.
+- **`buildEnd`** — after the build, generates all AEO files (robots.txt, llms.txt, sitemap.xml, ai-index.json, …) into the VitePress output directory.
+
+`url`, `title`, and `description` default from your VitePress site config (and `sitemap.hostname`) when omitted.
+
+<Aside type="tip">
+Any `transformHtml` or `buildEnd` hooks you already define are preserved — they run first, then aeo.js adds its behavior. These hooks only run during `vitepress build`, not the dev server.
+</Aside>
+
+## Configuration
+
+Pass any [AeoConfig](/reference/configuration/) options as the second argument. Add pages VitePress doesn't emit via `pages` — your entries always win:
+
+```ts
+withAeo(config, {
+  url: 'https://mysite.com',
+  title: 'My Docs',
+  schema: { organization: { name: 'My Company' } },
+});
+```


### PR DESCRIPTION
Adds **VitePress** support — Vue-powered docs SSG; docs are prime AEO/LLM content, and it's Vite-based so this is a natural fit.

## Approach
A `withAeo(config, options)` wrapper that composes two VitePress build hooks:
- **`transformHtml`** — per page: collects url/title/description/rendered content and injects the AEO widget before `</body>`.
- **`buildEnd`** — generates robots.txt / sitemap.xml / llms.txt / llms-full.txt / ai-index.json / manifest into the VitePress output dir.

Any `transformHtml`/`buildEnd` you already define are preserved (run first). `url`/`title`/`description` default from the VitePress site config and `sitemap.hostname`.

```ts
// .vitepress/config.ts
import { defineConfig } from 'vitepress';
import { withAeo } from 'aeo.js/vitepress';
export default defineConfig(withAeo({ title: 'My Docs' }, { url: 'https://mysite.com' }));
```

## Acceptance criteria
- [x] Unit tests: page collection + generation, widget inject/disabled, siteConfig/`sitemap.hostname` defaults, user-hook preservation, `config.pages` override. **315 tests pass** (7 new).
- [x] `npm run lint` (`tsc --noEmit`) clean — no `any`; return type guarantees the composed hooks (`Omit<T, …> & Required<VitePressUserConfig>`). No `vitepress` dependency (local interfaces).
- [x] `npm run build` emits `dist/vitepress.{js,mjs,d.ts}`.
- [x] Wired: tsup entry, `./vitepress` export, README, website docs page + sidebar (website builds clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)