### PR TITLE
fix(website): drop phantom /docs/* sitemap URLs (set contentDir)

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -10,6 +10,10 @@ export default defineConfig({
 			title: 'aeo.js — Answer Engine Optimization for the Modern Web',
 			description: 'Make your website discoverable by ChatGPT, Claude, Perplexity & AI search engines. Auto-generates llms.txt, robots.txt, sitemap, JSON-LD structured data & more.',
 			url: 'https://aeojs.org',
+			// Starlight serves src/content/docs/** at the site root, so point the
+			// content scan at the collection root. Without this it defaults to
+			// 'src/content' and emits phantom /docs/* URLs (404s) in the sitemap.
+			contentDir: 'src/content/docs',
 			schema: {
 				organization: {
 					name: 'aeo.js',


### PR DESCRIPTION
## Problem
The site's sitemap contained **26 phantom `/docs/*` URLs that 404** — exact duplicates of the 26 real URLs. e.g. it listed both `/frameworks/vitepress` (real) and `/docs/frameworks/vitepress` (404).

Root cause: `aeoAstroIntegration` defaulted `contentDir` to `src/content`, so the content scan turned `src/content/docs/frameworks/vitepress.mdx` into `/docs/frameworks/vitepress` — but Starlight serves content-collection docs at the site **root** (`/frameworks/vitepress`).

This wastes crawl budget and triggers "URLs return 404" warnings in Search Console.

## Fix
Set `contentDir: 'src/content/docs'` (the collection root) so scanned paths match the served routes.

**Verified locally:** sitemap goes from **53 → 28 URLs** with **zero `/docs/*` phantoms**.

## Known remainder (separate, library-level)
One phantom remains — `/index` (from `index.mdx` → `/index` instead of `/`). That's a bug in aeo.js's content-scan path derivation (doesn't collapse `index` to the parent), not fixable by config here. I can fix it in the library separately so it benefits every Starlight/Astro-content user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)