### PR TITLE
fix(core): collapse index files to root; add trailingSlash policy

### DIFF
--- a/src/core/ai-index.ts
+++ b/src/core/ai-index.ts
@@ -3,6 +3,7 @@ import { join, relative, extname } from 'path';
 import { createHash } from 'crypto';
 import type { ResolvedAeoConfig, AIIndexEntry } from '../types';
 import { parseFrontmatter, extractTitle } from './utils';
+import { buildPageUrl, contentFileToPathname } from './url';
 
 function extractKeywords(content: string, maxKeywords: number): string[] {
   if (maxKeywords < 1) return [];
@@ -65,8 +66,7 @@ function collectAIIndexEntries(dir: string, config: ResolvedAeoConfig, base: str
         const content = readFileSync(fullPath, 'utf-8');
         const { frontmatter, content: mainContent } = parseFrontmatter(content);
         const relativePath = relative(base, fullPath);
-        const urlPath = relativePath.replace(/\.mdx?$/, '');
-        const url = `${config.url}/${urlPath}`;
+        const url = buildPageUrl(config.url, contentFileToPathname(relativePath), config.trailingSlash);
         
         const chunks = chunkContent(mainContent, config.aiIndex.maxChunkLength);
         const title = frontmatter.title || extractTitle(mainContent);
@@ -112,7 +112,7 @@ export function generateAIIndex(config: ResolvedAeoConfig): string {
   // Add discovered pages from framework plugin
   if (config.pages && config.pages.length > 0) {
     for (const page of config.pages) {
-      const url = `${config.url}${page.pathname === '/' ? '' : page.pathname}`;
+      const url = buildPageUrl(config.url, page.pathname, config.trailingSlash);
       const title = page.title || page.pathname;
       const content = page.content || '';
 

--- a/src/core/llms-full.ts
+++ b/src/core/llms-full.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
 import { join, relative, extname } from 'path';
 import type { ResolvedAeoConfig } from '../types';
 import { parseFrontmatter, bumpHeadings } from './utils';
+import { buildPageUrl } from './url';
 
 function collectAndConcatenateMarkdown(dir: string, base: string = dir): string[] {
   const sections: string[] = [];
@@ -79,7 +80,7 @@ export function generateLlmsFullTxt(config: ResolvedAeoConfig): string {
   // Include discovered pages (from framework plugin)
   if (config.pages && config.pages.length > 0) {
     for (const page of config.pages) {
-      const url = `${config.url}${page.pathname === '/' ? '' : page.pathname}`;
+      const url = buildPageUrl(config.url, page.pathname, config.trailingSlash);
       const title = page.title || page.pathname;
       const sectionLines: string[] = [
         '---',

--- a/src/core/llms-txt.ts
+++ b/src/core/llms-txt.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
 import { join, relative, extname } from 'path';
 import type { ResolvedAeoConfig, MarkdownFile } from '../types';
 import { parseFrontmatter, extractTitle } from './utils';
+import { buildPageUrl, contentFileToPathname } from './url';
 
 function collectMarkdownFiles(dir: string, base: string = dir): MarkdownFile[] {
   const files: MarkdownFile[] = [];
@@ -60,7 +61,7 @@ export function generateLlmsTxt(config: ResolvedAeoConfig): string {
     lines.push('');
 
     for (const page of config.pages) {
-      const url = `${config.url}${page.pathname === '/' ? '' : page.pathname}`;
+      const url = buildPageUrl(config.url, page.pathname, config.trailingSlash);
       const title = page.title || page.pathname;
       lines.push(`- [${title}](${url})`);
       if (page.description) {
@@ -90,7 +91,7 @@ export function generateLlmsTxt(config: ResolvedAeoConfig): string {
       lines.push('');
 
       for (const file of files) {
-        const url = `${config.url}/${file.path.replace(/\.mdx?$/, '')}`;
+        const url = buildPageUrl(config.url, contentFileToPathname(file.path), config.trailingSlash);
         lines.push(`- [${file.title}](${url})`);
         if (file.description) {
           lines.push(`  ${file.description}`);

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
 import { join, relative, extname } from 'path';
 import type { ResolvedAeoConfig, ManifestEntry } from '../types';
 import { parseFrontmatter, extractTitle } from './utils';
+import { buildPageUrl, contentFileToPathname } from './url';
 
 function collectManifestEntries(dir: string, config: ResolvedAeoConfig, base: string = dir): ManifestEntry[] {
   const entries: ManifestEntry[] = [];
@@ -19,10 +20,9 @@ function collectManifestEntries(dir: string, config: ResolvedAeoConfig, base: st
         const content = readFileSync(fullPath, 'utf-8');
         const { frontmatter, content: mainContent } = parseFrontmatter(content);
         const relativePath = relative(base, fullPath);
-        const urlPath = relativePath.replace(/\.mdx?$/, '');
-        
+
         entries.push({
-          url: `${config.url}/${urlPath}`,
+          url: buildPageUrl(config.url, contentFileToPathname(relativePath), config.trailingSlash),
           title: frontmatter.title || extractTitle(mainContent),
           description: frontmatter.description,
           lastModified: stat.mtime.toISOString(),
@@ -43,7 +43,7 @@ export function generateManifest(config: ResolvedAeoConfig): string {
   if (config.pages && config.pages.length > 0) {
     for (const page of config.pages) {
       entries.push({
-        url: `${config.url}${page.pathname === '/' ? '' : page.pathname}`,
+        url: buildPageUrl(config.url, page.pathname, config.trailingSlash),
         title: page.title || page.pathname,
         description: page.description,
       });

--- a/src/core/sitemap.test.ts
+++ b/src/core/sitemap.test.ts
@@ -279,7 +279,9 @@ describe('generateSitemap', () => {
     
     const sitemap = generateSitemap(baseConfig);
     
-    expect(sitemap).toContain('<loc>https://example.com/index</loc>');
+    // index.md collapses to the site root, not /index
+    expect(sitemap).toContain('<loc>https://example.com</loc>');
+    expect(sitemap).not.toContain('<loc>https://example.com/index</loc>');
     expect(sitemap).toContain('<loc>https://example.com/blog/post1</loc>');
     expect(sitemap).toContain('<loc>https://example.com/blog/post2</loc>');
     expect(sitemap).toContain('<loc>https://example.com/docs/guide</loc>');

--- a/src/core/sitemap.ts
+++ b/src/core/sitemap.ts
@@ -1,6 +1,7 @@
 import { readdirSync, statSync, existsSync } from 'fs';
 import { join, relative, extname } from 'path';
 import type { ResolvedAeoConfig } from '../types';
+import { buildPageUrl, contentFileToPathname } from './url';
 
 function collectUrls(dir: string, config: ResolvedAeoConfig, base: string = dir): string[] {
   const urls: string[] = [];
@@ -17,8 +18,7 @@ function collectUrls(dir: string, config: ResolvedAeoConfig, base: string = dir)
         urls.push(...collectUrls(fullPath, config, base));
       } else if (stat.isFile() && (extname(entry) === '.md' || extname(entry) === '.mdx' || extname(entry) === '.html')) {
         const relativePath = relative(base, fullPath);
-        const urlPath = relativePath.replace(/\.(md|mdx|html)$/, '');
-        urls.push(`${config.url}/${urlPath}`);
+        urls.push(buildPageUrl(config.url, contentFileToPathname(relativePath), config.trailingSlash));
       }
     }
   } catch (error) {
@@ -63,7 +63,7 @@ export function generateSitemap(config: ResolvedAeoConfig): string {
   if (config.pages && config.pages.length > 0) {
     for (const page of config.pages) {
       if (isSitemapPathname(page.pathname)) continue;
-      urls.push(`${config.url}${page.pathname === '/' ? '' : page.pathname}`);
+      urls.push(buildPageUrl(config.url, page.pathname, config.trailingSlash));
     }
   }
 
@@ -81,7 +81,7 @@ export function generateSitemap(config: ResolvedAeoConfig): string {
   ];
 
   // Always include the site root
-  urls.push(config.url);
+  urls.push(buildPageUrl(config.url, '/', config.trailingSlash));
 
   const uniqueUrls = [...new Set(urls)].sort();
   

--- a/src/core/url.test.ts
+++ b/src/core/url.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { contentFileToPathname, buildPageUrl } from './url';
+
+describe('contentFileToPathname', () => {
+  it('collapses a top-level index file to the site root', () => {
+    expect(contentFileToPathname('index.md')).toBe('/');
+    expect(contentFileToPathname('index.mdx')).toBe('/');
+  });
+
+  it('collapses a nested index file to its directory', () => {
+    expect(contentFileToPathname('guide/index.md')).toBe('/guide');
+    expect(contentFileToPathname('a/b/index.mdx')).toBe('/a/b');
+  });
+
+  it('strips the extension for named files', () => {
+    expect(contentFileToPathname('features/audit.mdx')).toBe('/features/audit');
+    expect(contentFileToPathname('about.md')).toBe('/about');
+    expect(contentFileToPathname('page.html')).toBe('/page');
+  });
+});
+
+describe('buildPageUrl', () => {
+  it('maps the site root to the bare base URL by default', () => {
+    expect(buildPageUrl('https://x.com', '/')).toBe('https://x.com');
+    expect(buildPageUrl('https://x.com/', '/')).toBe('https://x.com');
+  });
+
+  it("preserves the pathname's own trailing slash by default", () => {
+    expect(buildPageUrl('https://x.com', '/about')).toBe('https://x.com/about');
+    expect(buildPageUrl('https://x.com', '/about/')).toBe('https://x.com/about/');
+  });
+
+  it("forces a trailing slash with 'always'", () => {
+    expect(buildPageUrl('https://x.com', '/about', 'always')).toBe('https://x.com/about/');
+    expect(buildPageUrl('https://x.com', '/about/', 'always')).toBe('https://x.com/about/');
+    expect(buildPageUrl('https://x.com', '/', 'always')).toBe('https://x.com/');
+  });
+
+  it("strips a trailing slash with 'never'", () => {
+    expect(buildPageUrl('https://x.com', '/about/', 'never')).toBe('https://x.com/about');
+    expect(buildPageUrl('https://x.com', '/about', 'never')).toBe('https://x.com/about');
+    expect(buildPageUrl('https://x.com', '/', 'never')).toBe('https://x.com');
+  });
+});

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -1,0 +1,40 @@
+export type TrailingSlash = 'always' | 'never' | 'preserve';
+
+/**
+ * Convert a content file's path (relative to the content directory) to a site
+ * pathname: strip the extension and collapse `index` files to their directory.
+ *
+ *   index.md            -> /
+ *   features/audit.mdx  -> /features/audit
+ *   guide/index.md      -> /guide
+ */
+export function contentFileToPathname(relativePath: string): string {
+  const p = relativePath
+    .replace(/\.(md|mdx|html)$/i, '')
+    .replace(/(^|\/)index$/i, '')
+    .replace(/^\/+/, '');
+  return p ? `/${p}` : '/';
+}
+
+/**
+ * Build an absolute page URL from a base URL and a pathname, applying the
+ * trailing-slash policy:
+ *   - 'preserve' (default): keep the pathname's own trailing slash
+ *   - 'always': force a trailing slash
+ *   - 'never': strip any trailing slash
+ * The site root maps to the bare base URL, or to `base + '/'` when 'always'.
+ */
+export function buildPageUrl(baseUrl: string, pathname: string, trailingSlash: TrailingSlash = 'preserve'): string {
+  const base = baseUrl.replace(/\/+$/, '');
+
+  if (pathname === '/' || pathname === '') {
+    return trailingSlash === 'always' ? `${base}/` : base;
+  }
+
+  let path = `/${pathname.replace(/^\/+/, '')}`;
+  if (trailingSlash === 'always') path = `${path.replace(/\/+$/, '')}/`;
+  else if (trailingSlash === 'never') path = path.replace(/\/+$/, '');
+  // 'preserve': leave the trailing slash exactly as provided
+
+  return base + path;
+}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -51,6 +51,7 @@ export function resolveConfig(config: AeoConfig = {}): ResolvedAeoConfig {
     url: config.url || 'https://example.com',
     contentDir: config.contentDir || frameworkInfo.contentDir,
     outDir: config.outDir || frameworkInfo.outDir,
+    trailingSlash: config.trailingSlash || 'preserve',
     pages: config.pages || [],
     generators: {
       robotsTxt: config.generators?.robotsTxt !== false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export interface AeoConfig {
   url?: string;
   contentDir?: string;
   outDir?: string;
+  /** Trailing-slash policy for generated URLs (sitemap, llms.txt, …). Default 'preserve'. */
+  trailingSlash?: 'always' | 'never' | 'preserve';
   pages?: PageEntry[];
   generators?: {
     robotsTxt?: boolean;
@@ -72,6 +74,7 @@ export interface ResolvedAeoConfig {
   url: string;
   contentDir: string;
   outDir: string;
+  trailingSlash?: 'always' | 'never' | 'preserve';
   pages: PageEntry[];
   generators: {
     robotsTxt: boolean;


### PR DESCRIPTION
Fixes the two library-level URL issues found while auditing the docs site's SEO.

## 1. Phantom `/index` URLs (index collapse)
The content-file → URL logic (`${url}/${relativePath-without-ext}`) was **duplicated across 5 generators** (sitemap, llms.txt, llms-full, manifest, ai-index) and never collapsed index files. So `index.md` produced `/index` (a 404) instead of `/`, and `guide/index.md` produced `/guide/index` instead of `/guide`.

Centralized into **`src/core/url.ts`**:
- `contentFileToPathname(relativePath)` — strips the extension and collapses `index` → directory (`index.md` → `/`, `guide/index.md` → `/guide`).

## 2. Trailing-slash policy
- `buildPageUrl(base, pathname, trailingSlash)` — `'preserve'` (default, **backward-compatible**), `'always'`, or `'never'`. New `trailingSlash` config option lets sites match their canonical form (e.g. Starlight canonicalizes with a trailing slash → set `trailingSlash: 'always'`).

## Why centralize
The duplicated logic is exactly the drift risk that caused earlier path bugs (#74/#75). All five generators now share one helper.

## Acceptance criteria
- [x] New `core/url.test.ts`: index collapse + all three trailing-slash policies. **322 tests pass** (7 new).
- [x] Updated the sitemap test that asserted the old `/index` behavior.
- [x] `tsc --noEmit` clean; `npm run build` clean.
- [x] Backward compatible — default `'preserve'` keeps existing output; only index-collapse changes.

## Follow-up (not in this PR)
After release, the website can set `trailingSlash: 'always'` and bump its `aeo.js` dep to eliminate the last `/index` entry and align sitemap URLs with canonicals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)